### PR TITLE
add missing deps to vendor

### DIFF
--- a/vendor/github.com/emicklei/go-restful/swagger/CHANGES.md
+++ b/vendor/github.com/emicklei/go-restful/swagger/CHANGES.md
@@ -1,0 +1,43 @@
+Change history of swagger
+=
+2015-10-16
+- add type override mechanism for swagger models (MR 254, nathanejohnson)
+- replace uses of wildcard in generated apidocs (issue 251)
+
+2015-05-25
+- (api break) changed the type of Properties in Model
+- (api break) changed the type of Models in ApiDeclaration
+- (api break) changed the parameter type of PostBuildDeclarationMapFunc
+
+2015-04-09
+- add ModelBuildable interface for customization of Model
+
+2015-03-17
+- preserve order of Routes per WebService in Swagger listing
+- fix use of $ref and type in Swagger models
+- add api version to listing
+
+2014-11-14
+- operation parameters are now sorted using ordering path,query,form,header,body
+
+2014-11-12
+- respect omitempty tag value for embedded structs
+- expose ApiVersion of WebService to Swagger ApiDeclaration
+
+2014-05-29
+- (api add) Ability to define custom http.Handler to serve swagger-ui static files
+
+2014-05-04
+- (fix) include model for array element type of response
+
+2014-01-03
+- (fix) do not add primitive type to the Api models
+
+2013-11-27
+- (fix) make Swagger work for WebServices with root ("/" or "") paths
+
+2013-10-29
+- (api add) package variable LogInfo to customize logging function
+
+2013-10-15
+- upgraded to spec version 1.2 (https://github.com/wordnik/swagger-core/wiki/1.2-transition)

--- a/vendor/github.com/emicklei/go-restful/swagger/README.md
+++ b/vendor/github.com/emicklei/go-restful/swagger/README.md
@@ -1,0 +1,76 @@
+How to use Swagger UI with go-restful
+=
+
+Get the Swagger UI sources (version 1.2 only)
+
+	git clone https://github.com/wordnik/swagger-ui.git
+	
+The project contains a "dist" folder.
+Its contents has all the Swagger UI files you need.
+
+The `index.html` has an `url` set to `http://petstore.swagger.wordnik.com/api/api-docs`.
+You need to change that to match your WebService JSON endpoint  e.g. `http://localhost:8080/apidocs.json`
+
+Now, you can install the Swagger WebService for serving the Swagger specification in JSON.
+
+	config := swagger.Config{
+		WebServices:    restful.RegisteredWebServices(),
+		ApiPath:        "/apidocs.json",
+		SwaggerPath:     "/apidocs/",
+		SwaggerFilePath: "/Users/emicklei/Projects/swagger-ui/dist"}
+	swagger.InstallSwaggerService(config)		
+	
+	
+Documenting Structs
+--
+
+Currently there are 2 ways to document your structs in the go-restful Swagger.
+
+###### By using struct tags
+- Use tag "description" to annotate a struct field with a description to show in the UI
+- Use tag "modelDescription" to annotate the struct itself with a description to show in the UI. The tag can be added in an field of the struct and in case that there are multiple definition, they will be appended with an empty line.
+
+###### By using the SwaggerDoc method
+Here is an example with an `Address` struct and the documentation for each of the fields. The `""` is a special entry for **documenting the struct itself**.
+
+	type Address struct {
+		Country  string `json:"country,omitempty"`
+		PostCode int    `json:"postcode,omitempty"`
+	}
+
+	func (Address) SwaggerDoc() map[string]string {
+		return map[string]string{
+			"":         "Address doc",
+			"country":  "Country doc",
+			"postcode": "PostCode doc",
+		}
+	}
+
+This example will generate a JSON like this
+
+	{
+		"Address": {
+			"id": "Address",
+			"description": "Address doc",
+			"properties": {
+				"country": {
+				"type": "string",
+				"description": "Country doc"
+				},
+				"postcode": {
+				"type": "integer",
+				"format": "int32",
+				"description": "PostCode doc"
+				}
+			}
+		}
+	}
+
+**Very Important Notes:**
+- `SwaggerDoc()` is using a **NON-Pointer** receiver (e.g. func (Address) and not func (*Address))
+- The returned map should use as key the name of the field as defined in the JSON parameter (e.g. `"postcode"` and not `"PostCode"`)
+
+Notes
+--
+- The Nickname of an Operation is automatically set by finding the name of the function. You can override it using RouteBuilder.Operation(..) 
+- The WebServices field of swagger.Config can be used to control which service you want to expose and document ; you can have multiple configs and therefore multiple endpoints.

--- a/vendor/github.com/emicklei/go-restful/swagger/api_declaration_list.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/api_declaration_list.go
@@ -1,0 +1,64 @@
+package swagger
+
+// Copyright 2015 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// ApiDeclarationList maintains an ordered list of ApiDeclaration.
+type ApiDeclarationList struct {
+	List []ApiDeclaration
+}
+
+// At returns the ApiDeclaration by its path unless absent, then ok is false
+func (l *ApiDeclarationList) At(path string) (a ApiDeclaration, ok bool) {
+	for _, each := range l.List {
+		if each.ResourcePath == path {
+			return each, true
+		}
+	}
+	return a, false
+}
+
+// Put adds or replaces a ApiDeclaration with this name
+func (l *ApiDeclarationList) Put(path string, a ApiDeclaration) {
+	// maybe replace existing
+	for i, each := range l.List {
+		if each.ResourcePath == path {
+			// replace
+			l.List[i] = a
+			return
+		}
+	}
+	// add
+	l.List = append(l.List, a)
+}
+
+// Do enumerates all the properties, each with its assigned name
+func (l *ApiDeclarationList) Do(block func(path string, decl ApiDeclaration)) {
+	for _, each := range l.List {
+		block(each.ResourcePath, each)
+	}
+}
+
+// MarshalJSON writes the ModelPropertyList as if it was a map[string]ModelProperty
+func (l ApiDeclarationList) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	buf.WriteString("{\n")
+	for i, each := range l.List {
+		buf.WriteString("\"")
+		buf.WriteString(each.ResourcePath)
+		buf.WriteString("\": ")
+		encoder.Encode(each)
+		if i < len(l.List)-1 {
+			buf.WriteString(",\n")
+		}
+	}
+	buf.WriteString("}")
+	return buf.Bytes(), nil
+}

--- a/vendor/github.com/emicklei/go-restful/swagger/config.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/config.go
@@ -1,0 +1,34 @@
+package swagger
+
+import (
+	"net/http"
+
+	"github.com/emicklei/go-restful"
+)
+
+// PostBuildDeclarationMapFunc can be used to modify the api declaration map.
+type PostBuildDeclarationMapFunc func(apiDeclarationMap *ApiDeclarationList)
+
+type Config struct {
+	// url where the services are available, e.g. http://localhost:8080
+	// if left empty then the basePath of Swagger is taken from the actual request
+	WebServicesUrl string
+	// path where the JSON api is avaiable , e.g. /apidocs
+	ApiPath string
+	// [optional] path where the swagger UI will be served, e.g. /swagger
+	SwaggerPath string
+	// [optional] location of folder containing Swagger HTML5 application index.html
+	SwaggerFilePath string
+	// api listing is constructed from this list of restful WebServices.
+	WebServices []*restful.WebService
+	// will serve all static content (scripts,pages,images)
+	StaticHandler http.Handler
+	// [optional] on default CORS (Cross-Origin-Resource-Sharing) is enabled.
+	DisableCORS bool
+	// Top-level API version. Is reflected in the resource listing.
+	ApiVersion string
+	// If set then call this handler after building the complete ApiDeclaration Map
+	PostBuildHandler PostBuildDeclarationMapFunc
+	// Swagger global info struct
+	Info Info
+}

--- a/vendor/github.com/emicklei/go-restful/swagger/model_builder.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/model_builder.go
@@ -1,0 +1,419 @@
+package swagger
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+)
+
+// ModelBuildable is used for extending Structs that need more control over
+// how the Model appears in the Swagger api declaration.
+type ModelBuildable interface {
+	PostBuildModel(m *Model) *Model
+}
+
+type modelBuilder struct {
+	Models *ModelList
+}
+
+type documentable interface {
+	SwaggerDoc() map[string]string
+}
+
+// Check if this structure has a method with signature func (<theModel>) SwaggerDoc() map[string]string
+// If it exists, retrive the documentation and overwrite all struct tag descriptions
+func getDocFromMethodSwaggerDoc2(model reflect.Type) map[string]string {
+	if docable, ok := reflect.New(model).Elem().Interface().(documentable); ok {
+		return docable.SwaggerDoc()
+	}
+	return make(map[string]string)
+}
+
+// addModelFrom creates and adds a Model to the builder and detects and calls
+// the post build hook for customizations
+func (b modelBuilder) addModelFrom(sample interface{}) {
+	if modelOrNil := b.addModel(reflect.TypeOf(sample), ""); modelOrNil != nil {
+		// allow customizations
+		if buildable, ok := sample.(ModelBuildable); ok {
+			modelOrNil = buildable.PostBuildModel(modelOrNil)
+			b.Models.Put(modelOrNil.Id, *modelOrNil)
+		}
+	}
+}
+
+func (b modelBuilder) addModel(st reflect.Type, nameOverride string) *Model {
+	modelName := b.keyFrom(st)
+	if nameOverride != "" {
+		modelName = nameOverride
+	}
+	// no models needed for primitive types
+	if b.isPrimitiveType(modelName) {
+		return nil
+	}
+	// see if we already have visited this model
+	if _, ok := b.Models.At(modelName); ok {
+		return nil
+	}
+	sm := Model{
+		Id:         modelName,
+		Required:   []string{},
+		Properties: ModelPropertyList{}}
+
+	// reference the model before further initializing (enables recursive structs)
+	b.Models.Put(modelName, sm)
+
+	// check for slice or array
+	if st.Kind() == reflect.Slice || st.Kind() == reflect.Array {
+		b.addModel(st.Elem(), "")
+		return &sm
+	}
+	// check for structure or primitive type
+	if st.Kind() != reflect.Struct {
+		return &sm
+	}
+
+	fullDoc := getDocFromMethodSwaggerDoc2(st)
+	modelDescriptions := []string{}
+
+	for i := 0; i < st.NumField(); i++ {
+		field := st.Field(i)
+		jsonName, modelDescription, prop := b.buildProperty(field, &sm, modelName)
+		if len(modelDescription) > 0 {
+			modelDescriptions = append(modelDescriptions, modelDescription)
+		}
+
+		// add if not omitted
+		if len(jsonName) != 0 {
+			// update description
+			if fieldDoc, ok := fullDoc[jsonName]; ok {
+				prop.Description = fieldDoc
+			}
+			// update Required
+			if b.isPropertyRequired(field) {
+				sm.Required = append(sm.Required, jsonName)
+			}
+			sm.Properties.Put(jsonName, prop)
+		}
+	}
+
+	// We always overwrite documentation if SwaggerDoc method exists
+	// "" is special for documenting the struct itself
+	if modelDoc, ok := fullDoc[""]; ok {
+		sm.Description = modelDoc
+	} else if len(modelDescriptions) != 0 {
+		sm.Description = strings.Join(modelDescriptions, "\n")
+	}
+
+	// update model builder with completed model
+	b.Models.Put(modelName, sm)
+
+	return &sm
+}
+
+func (b modelBuilder) isPropertyRequired(field reflect.StructField) bool {
+	required := true
+	if jsonTag := field.Tag.Get("json"); jsonTag != "" {
+		s := strings.Split(jsonTag, ",")
+		if len(s) > 1 && s[1] == "omitempty" {
+			return false
+		}
+	}
+	return required
+}
+
+func (b modelBuilder) buildProperty(field reflect.StructField, model *Model, modelName string) (jsonName, modelDescription string, prop ModelProperty) {
+	jsonName = b.jsonNameOfField(field)
+	if len(jsonName) == 0 {
+		// empty name signals skip property
+		return "", "", prop
+	}
+
+	if tag := field.Tag.Get("modelDescription"); tag != "" {
+		modelDescription = tag
+	}
+
+	prop.setPropertyMetadata(field)
+	if prop.Type != nil {
+		return jsonName, modelDescription, prop
+	}
+	fieldType := field.Type
+
+	// check if type is doing its own marshalling
+	marshalerType := reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+	if fieldType.Implements(marshalerType) {
+		var pType = "string"
+		if prop.Type == nil {
+			prop.Type = &pType
+		}
+		if prop.Format == "" {
+			prop.Format = b.jsonSchemaFormat(fieldType.String())
+		}
+		return jsonName, modelDescription, prop
+	}
+
+	// check if annotation says it is a string
+	if jsonTag := field.Tag.Get("json"); jsonTag != "" {
+		s := strings.Split(jsonTag, ",")
+		if len(s) > 1 && s[1] == "string" {
+			stringt := "string"
+			prop.Type = &stringt
+			return jsonName, modelDescription, prop
+		}
+	}
+
+	fieldKind := fieldType.Kind()
+	switch {
+	case fieldKind == reflect.Struct:
+		jsonName, prop := b.buildStructTypeProperty(field, jsonName, model)
+		return jsonName, modelDescription, prop
+	case fieldKind == reflect.Slice || fieldKind == reflect.Array:
+		jsonName, prop := b.buildArrayTypeProperty(field, jsonName, modelName)
+		return jsonName, modelDescription, prop
+	case fieldKind == reflect.Ptr:
+		jsonName, prop := b.buildPointerTypeProperty(field, jsonName, modelName)
+		return jsonName, modelDescription, prop
+	case fieldKind == reflect.String:
+		stringt := "string"
+		prop.Type = &stringt
+		return jsonName, modelDescription, prop
+	case fieldKind == reflect.Map:
+		// if it's a map, it's unstructured, and swagger 1.2 can't handle it
+		anyt := "any"
+		prop.Type = &anyt
+		return jsonName, modelDescription, prop
+	}
+
+	if b.isPrimitiveType(fieldType.String()) {
+		mapped := b.jsonSchemaType(fieldType.String())
+		prop.Type = &mapped
+		prop.Format = b.jsonSchemaFormat(fieldType.String())
+		return jsonName, modelDescription, prop
+	}
+	modelType := fieldType.String()
+	prop.Ref = &modelType
+
+	if fieldType.Name() == "" { // override type of anonymous structs
+		nestedTypeName := modelName + "." + jsonName
+		prop.Ref = &nestedTypeName
+		b.addModel(fieldType, nestedTypeName)
+	}
+	return jsonName, modelDescription, prop
+}
+
+func hasNamedJSONTag(field reflect.StructField) bool {
+	parts := strings.Split(field.Tag.Get("json"), ",")
+	if len(parts) == 0 {
+		return false
+	}
+	for _, s := range parts[1:] {
+		if s == "inline" {
+			return false
+		}
+	}
+	return len(parts[0]) > 0
+}
+
+func (b modelBuilder) buildStructTypeProperty(field reflect.StructField, jsonName string, model *Model) (nameJson string, prop ModelProperty) {
+	prop.setPropertyMetadata(field)
+	// Check for type override in tag
+	if prop.Type != nil {
+		return jsonName, prop
+	}
+	fieldType := field.Type
+	// check for anonymous
+	if len(fieldType.Name()) == 0 {
+		// anonymous
+		anonType := model.Id + "." + jsonName
+		b.addModel(fieldType, anonType)
+		prop.Ref = &anonType
+		return jsonName, prop
+	}
+
+	if field.Name == fieldType.Name() && field.Anonymous && !hasNamedJSONTag(field) {
+		// embedded struct
+		sub := modelBuilder{new(ModelList)}
+		sub.addModel(fieldType, "")
+		subKey := sub.keyFrom(fieldType)
+		// merge properties from sub
+		subModel, _ := sub.Models.At(subKey)
+		subModel.Properties.Do(func(k string, v ModelProperty) {
+			model.Properties.Put(k, v)
+			// if subModel says this property is required then include it
+			required := false
+			for _, each := range subModel.Required {
+				if k == each {
+					required = true
+					break
+				}
+			}
+			if required {
+				model.Required = append(model.Required, k)
+			}
+		})
+		// add all new referenced models
+		sub.Models.Do(func(key string, sub Model) {
+			if key != subKey {
+				if _, ok := b.Models.At(key); !ok {
+					b.Models.Put(key, sub)
+				}
+			}
+		})
+		// empty name signals skip property
+		return "", prop
+	}
+	// simple struct
+	b.addModel(fieldType, "")
+	var pType = fieldType.String()
+	prop.Ref = &pType
+	return jsonName, prop
+}
+
+func (b modelBuilder) buildArrayTypeProperty(field reflect.StructField, jsonName, modelName string) (nameJson string, prop ModelProperty) {
+	// check for type override in tags
+	prop.setPropertyMetadata(field)
+	if prop.Type != nil {
+		return jsonName, prop
+	}
+	fieldType := field.Type
+	var pType = "array"
+	prop.Type = &pType
+	elemTypeName := b.getElementTypeName(modelName, jsonName, fieldType.Elem())
+	prop.Items = new(Item)
+	if b.isPrimitiveType(elemTypeName) {
+		mapped := b.jsonSchemaType(elemTypeName)
+		prop.Items.Type = &mapped
+	} else {
+		prop.Items.Ref = &elemTypeName
+	}
+	// add|overwrite model for element type
+	if fieldType.Elem().Kind() == reflect.Ptr {
+		fieldType = fieldType.Elem()
+	}
+	b.addModel(fieldType.Elem(), elemTypeName)
+	return jsonName, prop
+}
+
+func (b modelBuilder) buildPointerTypeProperty(field reflect.StructField, jsonName, modelName string) (nameJson string, prop ModelProperty) {
+	prop.setPropertyMetadata(field)
+	// Check for type override in tags
+	if prop.Type != nil {
+		return jsonName, prop
+	}
+	fieldType := field.Type
+
+	// override type of pointer to list-likes
+	if fieldType.Elem().Kind() == reflect.Slice || fieldType.Elem().Kind() == reflect.Array {
+		var pType = "array"
+		prop.Type = &pType
+		elemName := b.getElementTypeName(modelName, jsonName, fieldType.Elem().Elem())
+		prop.Items = &Item{Ref: &elemName}
+		// add|overwrite model for element type
+		b.addModel(fieldType.Elem().Elem(), elemName)
+	} else {
+		// non-array, pointer type
+		var pType = b.jsonSchemaType(fieldType.String()[1:]) // no star, include pkg path
+		if b.isPrimitiveType(fieldType.String()[1:]) {
+			prop.Type = &pType
+			prop.Format = b.jsonSchemaFormat(fieldType.String()[1:])
+			return jsonName, prop
+		}
+		prop.Ref = &pType
+		elemName := ""
+		if fieldType.Elem().Name() == "" {
+			elemName = modelName + "." + jsonName
+			prop.Ref = &elemName
+		}
+		b.addModel(fieldType.Elem(), elemName)
+	}
+	return jsonName, prop
+}
+
+func (b modelBuilder) getElementTypeName(modelName, jsonName string, t reflect.Type) string {
+	if t.Kind() == reflect.Ptr {
+		return t.String()[1:]
+	}
+	if t.Name() == "" {
+		return modelName + "." + jsonName
+	}
+	if b.isPrimitiveType(t.Name()) {
+		return b.jsonSchemaType(t.Name())
+	}
+	return b.keyFrom(t)
+}
+
+func (b modelBuilder) keyFrom(st reflect.Type) string {
+	key := st.String()
+	if len(st.Name()) == 0 { // unnamed type
+		// Swagger UI has special meaning for [
+		key = strings.Replace(key, "[]", "||", -1)
+	}
+	return key
+}
+
+// see also https://golang.org/ref/spec#Numeric_types
+func (b modelBuilder) isPrimitiveType(modelName string) bool {
+	return strings.Contains("uint uint8 uint16 uint32 uint64 int int8 int16 int32 int64 float32 float64 bool string byte rune time.Time", modelName)
+}
+
+// jsonNameOfField returns the name of the field as it should appear in JSON format
+// An empty string indicates that this field is not part of the JSON representation
+func (b modelBuilder) jsonNameOfField(field reflect.StructField) string {
+	if jsonTag := field.Tag.Get("json"); jsonTag != "" {
+		s := strings.Split(jsonTag, ",")
+		if s[0] == "-" {
+			// empty name signals skip property
+			return ""
+		} else if s[0] != "" {
+			return s[0]
+		}
+	}
+	return field.Name
+}
+
+// see also http://json-schema.org/latest/json-schema-core.html#anchor8
+func (b modelBuilder) jsonSchemaType(modelName string) string {
+	schemaMap := map[string]string{
+		"uint":   "integer",
+		"uint8":  "integer",
+		"uint16": "integer",
+		"uint32": "integer",
+		"uint64": "integer",
+
+		"int":   "integer",
+		"int8":  "integer",
+		"int16": "integer",
+		"int32": "integer",
+		"int64": "integer",
+
+		"byte":      "integer",
+		"float64":   "number",
+		"float32":   "number",
+		"bool":      "boolean",
+		"time.Time": "string",
+	}
+	mapped, ok := schemaMap[modelName]
+	if !ok {
+		return modelName // use as is (custom or struct)
+	}
+	return mapped
+}
+
+func (b modelBuilder) jsonSchemaFormat(modelName string) string {
+	schemaMap := map[string]string{
+		"int":        "int32",
+		"int32":      "int32",
+		"int64":      "int64",
+		"byte":       "byte",
+		"uint":       "integer",
+		"uint8":      "byte",
+		"float64":    "double",
+		"float32":    "float",
+		"time.Time":  "date-time",
+		"*time.Time": "date-time",
+	}
+	mapped, ok := schemaMap[modelName]
+	if !ok {
+		return "" // no format
+	}
+	return mapped
+}

--- a/vendor/github.com/emicklei/go-restful/swagger/model_list.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/model_list.go
@@ -1,0 +1,86 @@
+package swagger
+
+// Copyright 2015 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// NamedModel associates a name with a Model (not using its Id)
+type NamedModel struct {
+	Name  string
+	Model Model
+}
+
+// ModelList encapsulates a list of NamedModel (association)
+type ModelList struct {
+	List []NamedModel
+}
+
+// Put adds or replaces a Model by its name
+func (l *ModelList) Put(name string, model Model) {
+	for i, each := range l.List {
+		if each.Name == name {
+			// replace
+			l.List[i] = NamedModel{name, model}
+			return
+		}
+	}
+	// add
+	l.List = append(l.List, NamedModel{name, model})
+}
+
+// At returns a Model by its name, ok is false if absent
+func (l *ModelList) At(name string) (m Model, ok bool) {
+	for _, each := range l.List {
+		if each.Name == name {
+			return each.Model, true
+		}
+	}
+	return m, false
+}
+
+// Do enumerates all the models, each with its assigned name
+func (l *ModelList) Do(block func(name string, value Model)) {
+	for _, each := range l.List {
+		block(each.Name, each.Model)
+	}
+}
+
+// MarshalJSON writes the ModelList as if it was a map[string]Model
+func (l ModelList) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	buf.WriteString("{\n")
+	for i, each := range l.List {
+		buf.WriteString("\"")
+		buf.WriteString(each.Name)
+		buf.WriteString("\": ")
+		encoder.Encode(each.Model)
+		if i < len(l.List)-1 {
+			buf.WriteString(",\n")
+		}
+	}
+	buf.WriteString("}")
+	return buf.Bytes(), nil
+}
+
+// UnmarshalJSON reads back a ModelList. This is an expensive operation.
+func (l *ModelList) UnmarshalJSON(data []byte) error {
+	raw := map[string]interface{}{}
+	json.NewDecoder(bytes.NewReader(data)).Decode(&raw)
+	for k, v := range raw {
+		// produces JSON bytes for each value
+		data, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
+		var m Model
+		json.NewDecoder(bytes.NewReader(data)).Decode(&m)
+		l.Put(k, m)
+	}
+	return nil
+}

--- a/vendor/github.com/emicklei/go-restful/swagger/model_property_ext.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/model_property_ext.go
@@ -1,0 +1,66 @@
+package swagger
+
+import (
+	"reflect"
+	"strings"
+)
+
+func (prop *ModelProperty) setDescription(field reflect.StructField) {
+	if tag := field.Tag.Get("description"); tag != "" {
+		prop.Description = tag
+	}
+}
+
+func (prop *ModelProperty) setDefaultValue(field reflect.StructField) {
+	if tag := field.Tag.Get("default"); tag != "" {
+		prop.DefaultValue = Special(tag)
+	}
+}
+
+func (prop *ModelProperty) setEnumValues(field reflect.StructField) {
+	// We use | to separate the enum values.  This value is chosen
+	// since its unlikely to be useful in actual enumeration values.
+	if tag := field.Tag.Get("enum"); tag != "" {
+		prop.Enum = strings.Split(tag, "|")
+	}
+}
+
+func (prop *ModelProperty) setMaximum(field reflect.StructField) {
+	if tag := field.Tag.Get("maximum"); tag != "" {
+		prop.Maximum = tag
+	}
+}
+
+func (prop *ModelProperty) setType(field reflect.StructField) {
+	if tag := field.Tag.Get("type"); tag != "" {
+		prop.Type = &tag
+	}
+}
+
+func (prop *ModelProperty) setMinimum(field reflect.StructField) {
+	if tag := field.Tag.Get("minimum"); tag != "" {
+		prop.Minimum = tag
+	}
+}
+
+func (prop *ModelProperty) setUniqueItems(field reflect.StructField) {
+	tag := field.Tag.Get("unique")
+	switch tag {
+	case "true":
+		v := true
+		prop.UniqueItems = &v
+	case "false":
+		v := false
+		prop.UniqueItems = &v
+	}
+}
+
+func (prop *ModelProperty) setPropertyMetadata(field reflect.StructField) {
+	prop.setDescription(field)
+	prop.setEnumValues(field)
+	prop.setMinimum(field)
+	prop.setMaximum(field)
+	prop.setUniqueItems(field)
+	prop.setDefaultValue(field)
+	prop.setType(field)
+}

--- a/vendor/github.com/emicklei/go-restful/swagger/model_property_list.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/model_property_list.go
@@ -1,0 +1,87 @@
+package swagger
+
+// Copyright 2015 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// NamedModelProperty associates a name to a ModelProperty
+type NamedModelProperty struct {
+	Name     string
+	Property ModelProperty
+}
+
+// ModelPropertyList encapsulates a list of NamedModelProperty (association)
+type ModelPropertyList struct {
+	List []NamedModelProperty
+}
+
+// At returns the ModelPropety by its name unless absent, then ok is false
+func (l *ModelPropertyList) At(name string) (p ModelProperty, ok bool) {
+	for _, each := range l.List {
+		if each.Name == name {
+			return each.Property, true
+		}
+	}
+	return p, false
+}
+
+// Put adds or replaces a ModelProperty with this name
+func (l *ModelPropertyList) Put(name string, prop ModelProperty) {
+	// maybe replace existing
+	for i, each := range l.List {
+		if each.Name == name {
+			// replace
+			l.List[i] = NamedModelProperty{Name: name, Property: prop}
+			return
+		}
+	}
+	// add
+	l.List = append(l.List, NamedModelProperty{Name: name, Property: prop})
+}
+
+// Do enumerates all the properties, each with its assigned name
+func (l *ModelPropertyList) Do(block func(name string, value ModelProperty)) {
+	for _, each := range l.List {
+		block(each.Name, each.Property)
+	}
+}
+
+// MarshalJSON writes the ModelPropertyList as if it was a map[string]ModelProperty
+func (l ModelPropertyList) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	buf.WriteString("{\n")
+	for i, each := range l.List {
+		buf.WriteString("\"")
+		buf.WriteString(each.Name)
+		buf.WriteString("\": ")
+		encoder.Encode(each.Property)
+		if i < len(l.List)-1 {
+			buf.WriteString(",\n")
+		}
+	}
+	buf.WriteString("}")
+	return buf.Bytes(), nil
+}
+
+// UnmarshalJSON reads back a ModelPropertyList. This is an expensive operation.
+func (l *ModelPropertyList) UnmarshalJSON(data []byte) error {
+	raw := map[string]interface{}{}
+	json.NewDecoder(bytes.NewReader(data)).Decode(&raw)
+	for k, v := range raw {
+		// produces JSON bytes for each value
+		data, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
+		var m ModelProperty
+		json.NewDecoder(bytes.NewReader(data)).Decode(&m)
+		l.Put(k, m)
+	}
+	return nil
+}

--- a/vendor/github.com/emicklei/go-restful/swagger/ordered_route_map.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/ordered_route_map.go
@@ -1,0 +1,36 @@
+package swagger
+
+// Copyright 2015 Ernest Micklei. All rights reserved.
+// Use of this source code is governed by a license
+// that can be found in the LICENSE file.
+
+import "github.com/emicklei/go-restful"
+
+type orderedRouteMap struct {
+	elements map[string][]restful.Route
+	keys     []string
+}
+
+func newOrderedRouteMap() *orderedRouteMap {
+	return &orderedRouteMap{
+		elements: map[string][]restful.Route{},
+		keys:     []string{},
+	}
+}
+
+func (o *orderedRouteMap) Add(key string, route restful.Route) {
+	routes, ok := o.elements[key]
+	if ok {
+		routes = append(routes, route)
+		o.elements[key] = routes
+		return
+	}
+	o.elements[key] = []restful.Route{route}
+	o.keys = append(o.keys, key)
+}
+
+func (o *orderedRouteMap) Do(block func(key string, routes []restful.Route)) {
+	for _, k := range o.keys {
+		block(k, o.elements[k])
+	}
+}

--- a/vendor/github.com/emicklei/go-restful/swagger/swagger.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/swagger.go
@@ -1,0 +1,184 @@
+// Package swagger implements the structures of the Swagger
+// https://github.com/wordnik/swagger-spec/blob/master/versions/1.2.md
+package swagger
+
+const swaggerVersion = "1.2"
+
+// 4.3.3 Data Type Fields
+type DataTypeFields struct {
+	Type         *string  `json:"type,omitempty"` // if Ref not used
+	Ref          *string  `json:"$ref,omitempty"` // if Type not used
+	Format       string   `json:"format,omitempty"`
+	DefaultValue Special  `json:"defaultValue,omitempty"`
+	Enum         []string `json:"enum,omitempty"`
+	Minimum      string   `json:"minimum,omitempty"`
+	Maximum      string   `json:"maximum,omitempty"`
+	Items        *Item    `json:"items,omitempty"`
+	UniqueItems  *bool    `json:"uniqueItems,omitempty"`
+}
+
+type Special string
+
+// 4.3.4 Items Object
+type Item struct {
+	Type   *string `json:"type,omitempty"`
+	Ref    *string `json:"$ref,omitempty"`
+	Format string  `json:"format,omitempty"`
+}
+
+// 5.1 Resource Listing
+type ResourceListing struct {
+	SwaggerVersion string          `json:"swaggerVersion"` // e.g 1.2
+	Apis           []Resource      `json:"apis"`
+	ApiVersion     string          `json:"apiVersion"`
+	Info           Info            `json:"info"`
+	Authorizations []Authorization `json:"authorizations,omitempty"`
+}
+
+// 5.1.2 Resource Object
+type Resource struct {
+	Path        string `json:"path"` // relative or absolute, must start with /
+	Description string `json:"description"`
+}
+
+// 5.1.3 Info Object
+type Info struct {
+	Title             string `json:"title"`
+	Description       string `json:"description"`
+	TermsOfServiceUrl string `json:"termsOfServiceUrl,omitempty"`
+	Contact           string `json:"contact,omitempty"`
+	License           string `json:"license,omitempty"`
+	LicenseUrl        string `json:"licenseUrl,omitempty"`
+}
+
+// 5.1.5
+type Authorization struct {
+	Type       string      `json:"type"`
+	PassAs     string      `json:"passAs"`
+	Keyname    string      `json:"keyname"`
+	Scopes     []Scope     `json:"scopes"`
+	GrantTypes []GrantType `json:"grandTypes"`
+}
+
+// 5.1.6, 5.2.11
+type Scope struct {
+	// Required. The name of the scope.
+	Scope string `json:"scope"`
+	// Recommended. A short description of the scope.
+	Description string `json:"description"`
+}
+
+// 5.1.7
+type GrantType struct {
+	Implicit          Implicit          `json:"implicit"`
+	AuthorizationCode AuthorizationCode `json:"authorization_code"`
+}
+
+// 5.1.8 Implicit Object
+type Implicit struct {
+	// Required. The login endpoint definition.
+	loginEndpoint LoginEndpoint `json:"loginEndpoint"`
+	// An optional alternative name to standard "access_token" OAuth2 parameter.
+	TokenName string `json:"tokenName"`
+}
+
+// 5.1.9 Authorization Code Object
+type AuthorizationCode struct {
+	TokenRequestEndpoint TokenRequestEndpoint `json:"tokenRequestEndpoint"`
+	TokenEndpoint        TokenEndpoint        `json:"tokenEndpoint"`
+}
+
+// 5.1.10 Login Endpoint Object
+type LoginEndpoint struct {
+	// Required. The URL of the authorization endpoint for the implicit grant flow. The value SHOULD be in a URL format.
+	Url string `json:"url"`
+}
+
+// 5.1.11 Token Request Endpoint Object
+type TokenRequestEndpoint struct {
+	// Required. The URL of the authorization endpoint for the authentication code grant flow. The value SHOULD be in a URL format.
+	Url string `json:"url"`
+	// An optional alternative name to standard "client_id" OAuth2 parameter.
+	ClientIdName string `json:"clientIdName"`
+	// An optional alternative name to the standard "client_secret" OAuth2 parameter.
+	ClientSecretName string `json:"clientSecretName"`
+}
+
+// 5.1.12 Token Endpoint Object
+type TokenEndpoint struct {
+	// Required. The URL of the token endpoint for the authentication code grant flow. The value SHOULD be in a URL format.
+	Url string `json:"url"`
+	// An optional alternative name to standard "access_token" OAuth2 parameter.
+	TokenName string `json:"tokenName"`
+}
+
+// 5.2 API Declaration
+type ApiDeclaration struct {
+	SwaggerVersion string          `json:"swaggerVersion"`
+	ApiVersion     string          `json:"apiVersion"`
+	BasePath       string          `json:"basePath"`
+	ResourcePath   string          `json:"resourcePath"` // must start with /
+	Apis           []Api           `json:"apis,omitempty"`
+	Models         ModelList       `json:"models,omitempty"`
+	Produces       []string        `json:"produces,omitempty"`
+	Consumes       []string        `json:"consumes,omitempty"`
+	Authorizations []Authorization `json:"authorizations,omitempty"`
+}
+
+// 5.2.2 API Object
+type Api struct {
+	Path        string      `json:"path"` // relative or absolute, must start with /
+	Description string      `json:"description"`
+	Operations  []Operation `json:"operations,omitempty"`
+}
+
+// 5.2.3 Operation Object
+type Operation struct {
+	DataTypeFields
+	Method           string            `json:"method"`
+	Summary          string            `json:"summary,omitempty"`
+	Notes            string            `json:"notes,omitempty"`
+	Nickname         string            `json:"nickname"`
+	Authorizations   []Authorization   `json:"authorizations,omitempty"`
+	Parameters       []Parameter       `json:"parameters"`
+	ResponseMessages []ResponseMessage `json:"responseMessages,omitempty"` // optional
+	Produces         []string          `json:"produces,omitempty"`
+	Consumes         []string          `json:"consumes,omitempty"`
+	Deprecated       string            `json:"deprecated,omitempty"`
+}
+
+// 5.2.4 Parameter Object
+type Parameter struct {
+	DataTypeFields
+	ParamType     string `json:"paramType"` // path,query,body,header,form
+	Name          string `json:"name"`
+	Description   string `json:"description"`
+	Required      bool   `json:"required"`
+	AllowMultiple bool   `json:"allowMultiple"`
+}
+
+// 5.2.5 Response Message Object
+type ResponseMessage struct {
+	Code          int    `json:"code"`
+	Message       string `json:"message"`
+	ResponseModel string `json:"responseModel,omitempty"`
+}
+
+// 5.2.6, 5.2.7 Models Object
+type Model struct {
+	Id            string            `json:"id"`
+	Description   string            `json:"description,omitempty"`
+	Required      []string          `json:"required,omitempty"`
+	Properties    ModelPropertyList `json:"properties"`
+	SubTypes      []string          `json:"subTypes,omitempty"`
+	Discriminator string            `json:"discriminator,omitempty"`
+}
+
+// 5.2.8 Properties Object
+type ModelProperty struct {
+	DataTypeFields
+	Description string `json:"description,omitempty"`
+}
+
+// 5.2.10
+type Authorizations map[string]Authorization

--- a/vendor/github.com/emicklei/go-restful/swagger/swagger_builder.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/swagger_builder.go
@@ -1,0 +1,21 @@
+package swagger
+
+type SwaggerBuilder struct {
+	SwaggerService
+}
+
+func NewSwaggerBuilder(config Config) *SwaggerBuilder {
+	return &SwaggerBuilder{*newSwaggerService(config)}
+}
+
+func (sb SwaggerBuilder) ProduceListing() ResourceListing {
+	return sb.SwaggerService.produceListing()
+}
+
+func (sb SwaggerBuilder) ProduceAllDeclarations() map[string]ApiDeclaration {
+	return sb.SwaggerService.produceAllDeclarations()
+}
+
+func (sb SwaggerBuilder) ProduceDeclarations(route string) (*ApiDeclaration, bool) {
+	return sb.SwaggerService.produceDeclarations(route)
+}

--- a/vendor/github.com/emicklei/go-restful/swagger/swagger_webservice.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/swagger_webservice.go
@@ -1,0 +1,440 @@
+package swagger
+
+import (
+	"fmt"
+
+	"github.com/emicklei/go-restful"
+	// "github.com/emicklei/hopwatch"
+	"net/http"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/emicklei/go-restful/log"
+)
+
+type SwaggerService struct {
+	config            Config
+	apiDeclarationMap *ApiDeclarationList
+}
+
+func newSwaggerService(config Config) *SwaggerService {
+	sws := &SwaggerService{
+		config:            config,
+		apiDeclarationMap: new(ApiDeclarationList)}
+
+	// Build all ApiDeclarations
+	for _, each := range config.WebServices {
+		rootPath := each.RootPath()
+		// skip the api service itself
+		if rootPath != config.ApiPath {
+			if rootPath == "" || rootPath == "/" {
+				// use routes
+				for _, route := range each.Routes() {
+					entry := staticPathFromRoute(route)
+					_, exists := sws.apiDeclarationMap.At(entry)
+					if !exists {
+						sws.apiDeclarationMap.Put(entry, sws.composeDeclaration(each, entry))
+					}
+				}
+			} else { // use root path
+				sws.apiDeclarationMap.Put(each.RootPath(), sws.composeDeclaration(each, each.RootPath()))
+			}
+		}
+	}
+
+	// if specified then call the PostBuilderHandler
+	if config.PostBuildHandler != nil {
+		config.PostBuildHandler(sws.apiDeclarationMap)
+	}
+	return sws
+}
+
+// LogInfo is the function that is called when this package needs to log. It defaults to log.Printf
+var LogInfo = func(format string, v ...interface{}) {
+	// use the restful package-wide logger
+	log.Printf(format, v...)
+}
+
+// InstallSwaggerService add the WebService that provides the API documentation of all services
+// conform the Swagger documentation specifcation. (https://github.com/wordnik/swagger-core/wiki).
+func InstallSwaggerService(aSwaggerConfig Config) {
+	RegisterSwaggerService(aSwaggerConfig, restful.DefaultContainer)
+}
+
+// RegisterSwaggerService add the WebService that provides the API documentation of all services
+// conform the Swagger documentation specifcation. (https://github.com/wordnik/swagger-core/wiki).
+func RegisterSwaggerService(config Config, wsContainer *restful.Container) {
+	sws := newSwaggerService(config)
+	ws := new(restful.WebService)
+	ws.Path(config.ApiPath)
+	ws.Produces(restful.MIME_JSON)
+	if config.DisableCORS {
+		ws.Filter(enableCORS)
+	}
+	ws.Route(ws.GET("/").To(sws.getListing))
+	ws.Route(ws.GET("/{a}").To(sws.getDeclarations))
+	ws.Route(ws.GET("/{a}/{b}").To(sws.getDeclarations))
+	ws.Route(ws.GET("/{a}/{b}/{c}").To(sws.getDeclarations))
+	ws.Route(ws.GET("/{a}/{b}/{c}/{d}").To(sws.getDeclarations))
+	ws.Route(ws.GET("/{a}/{b}/{c}/{d}/{e}").To(sws.getDeclarations))
+	ws.Route(ws.GET("/{a}/{b}/{c}/{d}/{e}/{f}").To(sws.getDeclarations))
+	ws.Route(ws.GET("/{a}/{b}/{c}/{d}/{e}/{f}/{g}").To(sws.getDeclarations))
+	LogInfo("[restful/swagger] listing is available at %v%v", config.WebServicesUrl, config.ApiPath)
+	wsContainer.Add(ws)
+
+	// Check paths for UI serving
+	if config.StaticHandler == nil && config.SwaggerFilePath != "" && config.SwaggerPath != "" {
+		swaggerPathSlash := config.SwaggerPath
+		// path must end with slash /
+		if "/" != config.SwaggerPath[len(config.SwaggerPath)-1:] {
+			LogInfo("[restful/swagger] use corrected SwaggerPath ; must end with slash (/)")
+			swaggerPathSlash += "/"
+		}
+
+		LogInfo("[restful/swagger] %v%v is mapped to folder %v", config.WebServicesUrl, swaggerPathSlash, config.SwaggerFilePath)
+		wsContainer.Handle(swaggerPathSlash, http.StripPrefix(swaggerPathSlash, http.FileServer(http.Dir(config.SwaggerFilePath))))
+
+		//if we define a custom static handler use it
+	} else if config.StaticHandler != nil && config.SwaggerPath != "" {
+		swaggerPathSlash := config.SwaggerPath
+		// path must end with slash /
+		if "/" != config.SwaggerPath[len(config.SwaggerPath)-1:] {
+			LogInfo("[restful/swagger] use corrected SwaggerFilePath ; must end with slash (/)")
+			swaggerPathSlash += "/"
+
+		}
+		LogInfo("[restful/swagger] %v%v is mapped to custom Handler %T", config.WebServicesUrl, swaggerPathSlash, config.StaticHandler)
+		wsContainer.Handle(swaggerPathSlash, config.StaticHandler)
+
+	} else {
+		LogInfo("[restful/swagger] Swagger(File)Path is empty ; no UI is served")
+	}
+}
+
+func staticPathFromRoute(r restful.Route) string {
+	static := r.Path
+	bracket := strings.Index(static, "{")
+	if bracket <= 1 { // result cannot be empty
+		return static
+	}
+	if bracket != -1 {
+		static = r.Path[:bracket]
+	}
+	if strings.HasSuffix(static, "/") {
+		return static[:len(static)-1]
+	} else {
+		return static
+	}
+}
+
+func enableCORS(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	if origin := req.HeaderParameter(restful.HEADER_Origin); origin != "" {
+		// prevent duplicate header
+		if len(resp.Header().Get(restful.HEADER_AccessControlAllowOrigin)) == 0 {
+			resp.AddHeader(restful.HEADER_AccessControlAllowOrigin, origin)
+		}
+	}
+	chain.ProcessFilter(req, resp)
+}
+
+func (sws SwaggerService) getListing(req *restful.Request, resp *restful.Response) {
+	listing := sws.produceListing()
+	resp.WriteAsJson(listing)
+}
+
+func (sws SwaggerService) produceListing() ResourceListing {
+	listing := ResourceListing{SwaggerVersion: swaggerVersion, ApiVersion: sws.config.ApiVersion, Info: sws.config.Info}
+	sws.apiDeclarationMap.Do(func(k string, v ApiDeclaration) {
+		ref := Resource{Path: k}
+		if len(v.Apis) > 0 { // use description of first (could still be empty)
+			ref.Description = v.Apis[0].Description
+		}
+		listing.Apis = append(listing.Apis, ref)
+	})
+	return listing
+}
+
+func (sws SwaggerService) getDeclarations(req *restful.Request, resp *restful.Response) {
+	decl, ok := sws.produceDeclarations(composeRootPath(req))
+	if !ok {
+		resp.WriteErrorString(http.StatusNotFound, "ApiDeclaration not found")
+		return
+	}
+	// unless WebServicesUrl is given
+	if len(sws.config.WebServicesUrl) == 0 {
+		// update base path from the actual request
+		// TODO how to detect https? assume http for now
+		var host string
+		// X-Forwarded-Host or Host or Request.Host
+		hostvalues, ok := req.Request.Header["X-Forwarded-Host"] // apache specific?
+		if !ok || len(hostvalues) == 0 {
+			forwarded, ok := req.Request.Header["Host"] // without reverse-proxy
+			if !ok || len(forwarded) == 0 {
+				// fallback to Host field
+				host = req.Request.Host
+			} else {
+				host = forwarded[0]
+			}
+		} else {
+			host = hostvalues[0]
+		}
+		// inspect Referer for the scheme (http vs https)
+		scheme := "http"
+		if referer := req.Request.Header["Referer"]; len(referer) > 0 {
+			if strings.HasPrefix(referer[0], "https") {
+				scheme = "https"
+			}
+		}
+		decl.BasePath = fmt.Sprintf("%s://%s", scheme, host)
+	}
+	resp.WriteAsJson(decl)
+}
+
+func (sws SwaggerService) produceAllDeclarations() map[string]ApiDeclaration {
+	decls := map[string]ApiDeclaration{}
+	sws.apiDeclarationMap.Do(func(k string, v ApiDeclaration) {
+		decls[k] = v
+	})
+	return decls
+}
+
+func (sws SwaggerService) produceDeclarations(route string) (*ApiDeclaration, bool) {
+	decl, ok := sws.apiDeclarationMap.At(route)
+	if !ok {
+		return nil, false
+	}
+	decl.BasePath = sws.config.WebServicesUrl
+	return &decl, true
+}
+
+// composeDeclaration uses all routes and parameters to create a ApiDeclaration
+func (sws SwaggerService) composeDeclaration(ws *restful.WebService, pathPrefix string) ApiDeclaration {
+	decl := ApiDeclaration{
+		SwaggerVersion: swaggerVersion,
+		BasePath:       sws.config.WebServicesUrl,
+		ResourcePath:   pathPrefix,
+		Models:         ModelList{},
+		ApiVersion:     ws.Version()}
+
+	// collect any path parameters
+	rootParams := []Parameter{}
+	for _, param := range ws.PathParameters() {
+		rootParams = append(rootParams, asSwaggerParameter(param.Data()))
+	}
+	// aggregate by path
+	pathToRoutes := newOrderedRouteMap()
+	for _, other := range ws.Routes() {
+		if strings.HasPrefix(other.Path, pathPrefix) {
+			pathToRoutes.Add(other.Path, other)
+		}
+	}
+	pathToRoutes.Do(func(path string, routes []restful.Route) {
+		api := Api{Path: strings.TrimSuffix(withoutWildcard(path), "/"), Description: ws.Documentation()}
+		voidString := "void"
+		for _, route := range routes {
+			operation := Operation{
+				Method:  route.Method,
+				Summary: route.Doc,
+				Notes:   route.Notes,
+				// Type gets overwritten if there is a write sample
+				DataTypeFields:   DataTypeFields{Type: &voidString},
+				Parameters:       []Parameter{},
+				Nickname:         route.Operation,
+				ResponseMessages: composeResponseMessages(route, &decl)}
+
+			operation.Consumes = route.Consumes
+			operation.Produces = route.Produces
+
+			// share root params if any
+			for _, swparam := range rootParams {
+				operation.Parameters = append(operation.Parameters, swparam)
+			}
+			// route specific params
+			for _, param := range route.ParameterDocs {
+				operation.Parameters = append(operation.Parameters, asSwaggerParameter(param.Data()))
+			}
+
+			sws.addModelsFromRouteTo(&operation, route, &decl)
+			api.Operations = append(api.Operations, operation)
+		}
+		decl.Apis = append(decl.Apis, api)
+	})
+	return decl
+}
+
+func withoutWildcard(path string) string {
+	if strings.HasSuffix(path, ":*}") {
+		return path[0:len(path)-3] + "}"
+	}
+	return path
+}
+
+// composeResponseMessages takes the ResponseErrors (if any) and creates ResponseMessages from them.
+func composeResponseMessages(route restful.Route, decl *ApiDeclaration) (messages []ResponseMessage) {
+	if route.ResponseErrors == nil {
+		return messages
+	}
+	// sort by code
+	codes := sort.IntSlice{}
+	for code, _ := range route.ResponseErrors {
+		codes = append(codes, code)
+	}
+	codes.Sort()
+	for _, code := range codes {
+		each := route.ResponseErrors[code]
+		message := ResponseMessage{
+			Code:    code,
+			Message: each.Message,
+		}
+		if each.Model != nil {
+			st := reflect.TypeOf(each.Model)
+			isCollection, st := detectCollectionType(st)
+			modelName := modelBuilder{}.keyFrom(st)
+			if isCollection {
+				modelName = "array[" + modelName + "]"
+			}
+			modelBuilder{&decl.Models}.addModel(st, "")
+			// reference the model
+			message.ResponseModel = modelName
+		}
+		messages = append(messages, message)
+	}
+	return
+}
+
+// addModelsFromRoute takes any read or write sample from the Route and creates a Swagger model from it.
+func (sws SwaggerService) addModelsFromRouteTo(operation *Operation, route restful.Route, decl *ApiDeclaration) {
+	if route.ReadSample != nil {
+		sws.addModelFromSampleTo(operation, false, route.ReadSample, &decl.Models)
+	}
+	if route.WriteSample != nil {
+		sws.addModelFromSampleTo(operation, true, route.WriteSample, &decl.Models)
+	}
+}
+
+func detectCollectionType(st reflect.Type) (bool, reflect.Type) {
+	isCollection := false
+	if st.Kind() == reflect.Slice || st.Kind() == reflect.Array {
+		st = st.Elem()
+		isCollection = true
+	} else {
+		if st.Kind() == reflect.Ptr {
+			if st.Elem().Kind() == reflect.Slice || st.Elem().Kind() == reflect.Array {
+				st = st.Elem().Elem()
+				isCollection = true
+			}
+		}
+	}
+	return isCollection, st
+}
+
+// addModelFromSample creates and adds (or overwrites) a Model from a sample resource
+func (sws SwaggerService) addModelFromSampleTo(operation *Operation, isResponse bool, sample interface{}, models *ModelList) {
+	if isResponse {
+		type_, items := asDataType(sample)
+		operation.Type = type_
+		operation.Items = items
+	}
+	modelBuilder{models}.addModelFrom(sample)
+}
+
+func asSwaggerParameter(param restful.ParameterData) Parameter {
+	return Parameter{
+		DataTypeFields: DataTypeFields{
+			Type:         &param.DataType,
+			Format:       asFormat(param.DataType, param.DataFormat),
+			DefaultValue: Special(param.DefaultValue),
+		},
+		Name:        param.Name,
+		Description: param.Description,
+		ParamType:   asParamType(param.Kind),
+
+		Required: param.Required}
+}
+
+// Between 1..7 path parameters is supported
+func composeRootPath(req *restful.Request) string {
+	path := "/" + req.PathParameter("a")
+	b := req.PathParameter("b")
+	if b == "" {
+		return path
+	}
+	path = path + "/" + b
+	c := req.PathParameter("c")
+	if c == "" {
+		return path
+	}
+	path = path + "/" + c
+	d := req.PathParameter("d")
+	if d == "" {
+		return path
+	}
+	path = path + "/" + d
+	e := req.PathParameter("e")
+	if e == "" {
+		return path
+	}
+	path = path + "/" + e
+	f := req.PathParameter("f")
+	if f == "" {
+		return path
+	}
+	path = path + "/" + f
+	g := req.PathParameter("g")
+	if g == "" {
+		return path
+	}
+	return path + "/" + g
+}
+
+func asFormat(dataType string, dataFormat string) string {
+	if dataFormat != "" {
+		return dataFormat
+	}
+	return "" // TODO
+}
+
+func asParamType(kind int) string {
+	switch {
+	case kind == restful.PathParameterKind:
+		return "path"
+	case kind == restful.QueryParameterKind:
+		return "query"
+	case kind == restful.BodyParameterKind:
+		return "body"
+	case kind == restful.HeaderParameterKind:
+		return "header"
+	case kind == restful.FormParameterKind:
+		return "form"
+	}
+	return ""
+}
+
+func asDataType(any interface{}) (*string, *Item) {
+	// If it's not a collection, return the suggested model name
+	st := reflect.TypeOf(any)
+	isCollection, st := detectCollectionType(st)
+	modelName := modelBuilder{}.keyFrom(st)
+	// if it's not a collection we are done
+	if !isCollection {
+		return &modelName, nil
+	}
+
+	// XXX: This is not very elegant
+	// We create an Item object referring to the given model
+	models := ModelList{}
+	mb := modelBuilder{&models}
+	mb.addModelFrom(any)
+
+	elemTypeName := mb.getElementTypeName(modelName, "", st)
+	item := new(Item)
+	if mb.isPrimitiveType(elemTypeName) {
+		mapped := mb.jsonSchemaType(elemTypeName)
+		item.Type = &mapped
+	} else {
+		item.Ref = &elemTypeName
+	}
+	tmp := "array"
+	return &tmp, item
+}

--- a/vendor/github.com/hashicorp/vault/api/client.go
+++ b/vendor/github.com/hashicorp/vault/api/client.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"path"
 
 	"golang.org/x/net/http2"
 
@@ -329,14 +330,14 @@ func (c *Client) ClearToken() {
 // NewRequest creates a new raw request object to query the Vault server
 // configured for this client. This is an advanced method and generally
 // doesn't need to be called externally.
-func (c *Client) NewRequest(method, path string) *Request {
+func (c *Client) NewRequest(method, requestPath string) *Request {
 	req := &Request{
 		Method: method,
 		URL: &url.URL{
 			User:   c.addr.User,
 			Scheme: c.addr.Scheme,
 			Host:   c.addr.Host,
-			Path:   path,
+			Path:   path.Join(c.addr.Path, requestPath),
 		},
 		ClientToken: c.token,
 		Params:      make(map[string][]string),
@@ -344,12 +345,12 @@ func (c *Client) NewRequest(method, path string) *Request {
 
 	var lookupPath string
 	switch {
-	case strings.HasPrefix(path, "/v1/"):
-		lookupPath = strings.TrimPrefix(path, "/v1/")
-	case strings.HasPrefix(path, "v1/"):
-		lookupPath = strings.TrimPrefix(path, "v1/")
+	case strings.HasPrefix(requestPath, "/v1/"):
+		lookupPath = strings.TrimPrefix(requestPath, "/v1/")
+	case strings.HasPrefix(requestPath, "v1/"):
+		lookupPath = strings.TrimPrefix(requestPath, "v1/")
 	default:
-		lookupPath = path
+		lookupPath = requestPath
 	}
 	if c.wrappingLookupFunc != nil {
 		req.WrapTTL = c.wrappingLookupFunc(method, lookupPath)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -124,8 +124,12 @@
 			"revisionTime": "2017-04-10T11:07:28Z"
 		},
 		{
+			"checksumSHA1": "2OofLhHRnS/xkDiAjKvn7LmY228=",
 			"path": "github.com/emicklei/go-restful/swagger",
-			"revision": ""
+			"revision": "777bb3f19bcafe2575ffb2a3e46af92509ae9594",
+			"revisionTime": "2015-11-26T14:56:26Z",
+			"version": "v1.2",
+			"versionExact": "v1.2"
 		},
 		{
 			"checksumSHA1": "40Ns85VYa4smQPcewZ7SOdfLnKU=",
@@ -300,10 +304,10 @@
 			"revisionTime": "2017-04-10T13:46:25Z"
 		},
 		{
-			"checksumSHA1": "NRXFJ+XdP3BcA8ABvHSxjqcOcEA=",
+			"checksumSHA1": "8VOnoB0DNWtRNMFvfuA8AuYOLik=",
 			"path": "github.com/hashicorp/vault/api",
-			"revision": "892d558fa286162f8370f1e9c2fc2de2f89c3861",
-			"revisionTime": "2017-04-10T13:46:25Z"
+			"revision": "f4ae1ff3f66a7fda006606aa491eab716160250c",
+			"revisionTime": "2017-05-04T21:08:02Z"
 		},
 		{
 			"checksumSHA1": "ft77GtqeZEeCXioGpF/s6DlGm/U=",


### PR DESCRIPTION
With this I am able to build again, within a "clean" go 1.8.1 environment.

Here's what I did:

Iterated on the build until it succeeded using the official go 1.8.1 container for the clean environment:
```
docker run --rm -v "$PWD":/go/src/github.com/roboll/kube-vault-controller -w /go/src/github.com/roboll/kube-vault-controller -it golang:1.8.1 make build
```

I ended up with the following commands being sufficient to fix the issue with missing deps:
```
govendor fetch github.com/hashicorp/vault/api
govendor fetch github.com/emicklei/go-restful/swagger@v1.2
```

Verified the newly built artifact
```
$ file kube-vault-controller
kube-vault-controller: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, not stripped
```