### PR TITLE
Add an option to only allow creating secrets in a namespaced path

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The controller is built with https://github.com/kubernetes/client-go, specifical
 
 This feature is useful if you are running a Kubernetes cluster as a service and want kube-vault-controller to namespace secrets access. 
 
-By adding a `--namespace-prefix` to the arguments you can ensure that all secretClaims created under this path will only be able to access their own namespace. Secrets that fall outside this path will still be globally accessible for the cluster.
+By adding a `--namespace-prefix` to the arguments you can ensure that all secretClaims starting with this prefix will only be able to access their own namespace. Secrets starting with this prefix need to be written to `${prefix}${namespace}/${key}`. Secrets that fall outside this path will still be globally accessible for the cluster. 
 
 ### Example usage
 
@@ -124,10 +124,12 @@ By adding a `--namespace-prefix` to the arguments you can ensure that all secret
   --namespace-prefix='secret/cluster-name/'
   ```
 
-Users inside of the namespace `example` will not only be able to create secretClaims under the path `secret/cluster-name/example/*`. If they try to access another path under the prefix that isn't their namespace they will see the following error:
+Secretclaims created in the namespace `example` will now only be able to create secretClaims with paths inside `secret/cluster-name/example/*`. If they try to access another path under the prefix that isn't their namespace they will see the following error:
 
 ```
 2019/11/26 10:52:09 error: failed to update secret for key example/not-allowed: vault-controller: "example/not-allowed": can't create path "secret/cluster-name/othernamespace/not-allowed" because it is under the namespacePrefix "secret/cluster-name/" but not in its own namespace "example"
 ```
+
+The prefix can be anything you want it to be. If you want your secrets to be in the form `secret/cluster-name/namespace` you will need to make sure that your prefix is exactly `secret/cluster-name/` with a trailing `/`. You could also use `secret/cluster-name_` as your prefix. This would mean secrets for the `example` namespace need to be written to `secret/cluster-name_example/key`. 
 
 You can also look at the [namespaced-secrets example](./example/namespaced-secrets.yaml) to get a better idea of how it works. 

--- a/example/namespaced-secrets.yaml
+++ b/example/namespaced-secrets.yaml
@@ -1,0 +1,29 @@
+# Examples of what will and won't work if using a namespace-prefix
+# --namespace-prefix=secret/cluster-name/
+---
+kind: SecretClaim
+apiVersion: vaultproject.io/v1
+metadata:
+  name: allowed
+  namespace: example
+spec:
+  type: Opaque
+  path: secret/cluster-name/example/key
+---
+kind: SecretClaim
+apiVersion: vaultproject.io/v1
+metadata:
+  name: not-allowed
+  namespace: othernamespace
+spec:
+  type: Opaque
+  path: secret/cluster-name/example/key
+---
+kind: SecretClaim
+apiVersion: vaultproject.io/v1
+metadata:
+  name: allowed-because-outside-of-prefix
+  namespace: example
+spec:
+  type: Opaque
+  path: secret/other-secret-path/key

--- a/main.go
+++ b/main.go
@@ -17,6 +17,8 @@ var (
 	kubeconfig = flag.String("kubeconfig", "", "Path to the kubeconfig file. Defaults to in-cluster config.")
 	namespace  = flag.String("namespace", "", "Namespace to watch for claims.")
 
+	namespacePrefix = flag.String("namespace-prefix", "", "Any claims with this prefix will only be accessible per namespace")
+
 	syncPeriod = flag.Duration("sync-period", 0, "Sync all resources each period.")
 )
 
@@ -26,6 +28,9 @@ func main() {
 	log.Printf("kube-vault-controller starting, sync period %s.", *syncPeriod)
 	if *namespace != "" {
 		log.Printf("watching namespace %s.", *namespace)
+	}
+	if *namespacePrefix != "" {
+		log.Printf("all secrets with prefix %s will be namespaced", *namespacePrefix)
 	}
 
 	vconfig := vault.DefaultConfig()
@@ -44,6 +49,7 @@ func main() {
 
 	config := &controller.Config{
 		Namespace:  *namespace,
+		NamespacePrefix: *namespacePrefix,
 		SyncPeriod: *syncPeriod,
 	}
 	ctrl, err := controller.New(config, vconfig, kconfig)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,7 +7,7 @@ import (
 	"github.com/roboll/kube-vault-controller/pkg/kube"
 	"github.com/roboll/kube-vault-controller/pkg/vault"
 
-	"k8s.io/client-go/pkg/api/v1"
+	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 )
@@ -18,8 +18,9 @@ type Controller struct {
 }
 
 type Config struct {
-	Namespace  string
-	SyncPeriod time.Duration
+	Namespace       string
+	NamespacePrefix string
+	SyncPeriod      time.Duration
 }
 
 func New(config *Config, vconfig *vaultapi.Config, kconfig *rest.Config) (*Controller, error) {
@@ -31,7 +32,7 @@ func New(config *Config, vconfig *vaultapi.Config, kconfig *rest.Config) (*Contr
 	if err != nil {
 		return nil, err
 	}
-	vaultController, err := vault.NewController(vconfig, kconfig)
+	vaultController, err := vault.NewController(vconfig, kconfig, config.NamespacePrefix)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/vault/controller_test.go
+++ b/pkg/vault/controller_test.go
@@ -119,6 +119,20 @@ func Test_pathAllowed(t *testing.T) {
 			namespace: "namespace",
 			want:      false,
 		},
+		{
+			name:      "Prefixes can be anything you like and doesn't need to end with a slash",
+			path:      "secret/testnamespace/key",
+			prefix:    "secret/test",
+			namespace: "namespace",
+			want:      true,
+		},
+		{
+			name:      "Prefixes can even be a dash",
+			path:      "secret/test-namespace/key",
+			prefix:    "secret/test-",
+			namespace: "namespace",
+			want:      true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/vault/controller_test.go
+++ b/pkg/vault/controller_test.go
@@ -82,3 +82,49 @@ func Test_buildSecretAnnotations(t *testing.T) {
 		})
 	}
 }
+
+func Test_pathAllowed(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		prefix    string
+		namespace string
+		want      bool
+	}{
+		{
+			name:      "Path is outside of prefix",
+			path:      "secret/path/key",
+			prefix:    "secret/otherpath/",
+			namespace: "namespace",
+			want:      true,
+		},
+		{
+			name:      "Path is inside the prefix and in the right namespace",
+			path:      "secret/path/namespace/key",
+			prefix:    "secret/path/",
+			namespace: "namespace",
+			want:      true,
+		},
+		{
+			name:      "Path is inside the prefix but accessing a different namespace",
+			path:      "secret/path/not-my-namespace/key",
+			prefix:    "secret/path/",
+			namespace: "namespace",
+			want:      false,
+		},
+		{
+			name:      "Path is inside the prefix but accessing a namespace that partially matches",
+			path:      "secret/path/namespacepartial/key",
+			prefix:    "secret/path/",
+			namespace: "namespace",
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := pathAllowed(tt.path, tt.prefix, tt.namespace); got != tt.want {
+				t.Errorf("pathAllowed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is a very rough WIP. I wanted to get some feedback about the idea
first before investing any extra time in it.

Why?

My team runs a "Kubernetes as a service" offering for other teams. Part
of this package is the kube-vault-controller to allow teams to sync
their secrets from vault into Kubernetes.

By default we give each team a single policy which allows them only
access to `k8s/$CLUSTER_NAME/*` and recommend that they write
secrets with paths like `k8s/$CLUSTER_NAME/$NAMESPACE/$APP`.

The issue is that there is no easy way to prevent one namespace from
claiming secrets from another namespace. It would be possible to
deploy kube-vault-controller per namespace with its own policy
however that adds a lot of extra overhead.

The idea behind this is that any secrets under namespacePrefix will only
be accessible per namespace.

So namespace `test` can only access secrets under
`k8s/$CLUSTER_NAME/test/*`.

Secretclaims in any other location still remain the same, so this allows
users to access shared secrets that are allowed by their
kube-vault-controller policy but only cluster specific secrets for their
namespace.