### PR TITLE
Add support for setting secret annotations

### DIFF
--- a/example/secret-with-annotations.yaml
+++ b/example/secret-with-annotations.yaml
@@ -1,0 +1,11 @@
+---
+kind: SecretClaim
+apiVersion: vaultproject.io/v1
+metadata:
+  name: secret-with-annotations
+spec:
+  type: Opaque
+  path: secret/example
+  annotations:
+    hello: "world"
+    foo: "bar"

--- a/pkg/kube/types.go
+++ b/pkg/kube/types.go
@@ -4,7 +4,7 @@ package kube
 import (
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/unversioned"
-	"k8s.io/client-go/pkg/api/v1"
+	v1 "k8s.io/client-go/pkg/api/v1"
 )
 
 const (
@@ -23,10 +23,11 @@ var (
 )
 
 type SecretSpec struct {
-	Type  v1.SecretType          `json:"type"`
-	Path  string                 `json:"path"`
-	Data  map[string]interface{} `json:"data"`
-	Renew int64                  `json:"renew"`
+	Type        v1.SecretType          `json:"type"`
+	Path        string                 `json:"path"`
+	Data        map[string]interface{} `json:"data"`
+	Renew       int64                  `json:"renew"`
+	Annotations map[string]string      `json:"annotations"`
 }
 
 type SecretClaim struct {

--- a/pkg/kube/types_codec.go
+++ b/pkg/kube/types_codec.go
@@ -20,25 +20,25 @@ import (
 
 const (
 	// ----- content types ----
-	codecSelferC_UTF84586 = 1
-	codecSelferC_RAW4586  = 0
+	codecSelferC_UTF86836 = 1
+	codecSelferC_RAW6836  = 0
 	// ----- value types used ----
-	codecSelferValueTypeArray4586 = 10
-	codecSelferValueTypeMap4586   = 9
+	codecSelferValueTypeArray6836 = 10
+	codecSelferValueTypeMap6836   = 9
 	// ----- containerStateValues ----
-	codecSelfer_containerMapKey4586    = 2
-	codecSelfer_containerMapValue4586  = 3
-	codecSelfer_containerMapEnd4586    = 4
-	codecSelfer_containerArrayElem4586 = 6
-	codecSelfer_containerArrayEnd4586  = 7
+	codecSelfer_containerMapKey6836    = 2
+	codecSelfer_containerMapValue6836  = 3
+	codecSelfer_containerMapEnd6836    = 4
+	codecSelfer_containerArrayElem6836 = 6
+	codecSelfer_containerArrayEnd6836  = 7
 )
 
 var (
-	codecSelferBitsize4586                         = uint8(reflect.TypeOf(uint(0)).Bits())
-	codecSelferOnlyMapOrArrayEncodeToStructErr4586 = errors.New(`only encoded map or array can be decoded into a struct`)
+	codecSelferBitsize6836                         = uint8(reflect.TypeOf(uint(0)).Bits())
+	codecSelferOnlyMapOrArrayEncodeToStructErr6836 = errors.New(`only encoded map or array can be decoded into a struct`)
 )
 
-type codecSelfer4586 struct{}
+type codecSelfer6836 struct{}
 
 func init() {
 	if codec1978.GenVersion != 5 {
@@ -58,7 +58,7 @@ func init() {
 }
 
 func (x *SecretSpec) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer4586
+	var h codecSelfer6836
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	if x == nil {
@@ -71,14 +71,14 @@ func (x *SecretSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 		} else {
 			yysep2 := !z.EncBinary()
 			yy2arr2 := z.EncBasicHandle().StructToArray
-			var yyq2 [4]bool
+			var yyq2 [5]bool
 			_, _, _ = yysep2, yyq2, yy2arr2
 			const yyr2 bool = false
 			var yynn2 int
 			if yyr2 || yy2arr2 {
-				r.EncodeArrayStart(4)
+				r.EncodeArrayStart(5)
 			} else {
-				yynn2 = 4
+				yynn2 = 5
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
@@ -88,37 +88,37 @@ func (x *SecretSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				yynn2 = 0
 			}
 			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem4586)
+				z.EncSendContainerState(codecSelfer_containerArrayElem6836)
 				yysf4 := &x.Type
 				yysf4.CodecEncodeSelf(e)
 			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey4586)
-				r.EncodeString(codecSelferC_UTF84586, string("type"))
-				z.EncSendContainerState(codecSelfer_containerMapValue4586)
+				z.EncSendContainerState(codecSelfer_containerMapKey6836)
+				r.EncodeString(codecSelferC_UTF86836, string("type"))
+				z.EncSendContainerState(codecSelfer_containerMapValue6836)
 				yysf5 := &x.Type
 				yysf5.CodecEncodeSelf(e)
 			}
 			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem4586)
+				z.EncSendContainerState(codecSelfer_containerArrayElem6836)
 				yym7 := z.EncBinary()
 				_ = yym7
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF84586, string(x.Path))
+					r.EncodeString(codecSelferC_UTF86836, string(x.Path))
 				}
 			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey4586)
-				r.EncodeString(codecSelferC_UTF84586, string("path"))
-				z.EncSendContainerState(codecSelfer_containerMapValue4586)
+				z.EncSendContainerState(codecSelfer_containerMapKey6836)
+				r.EncodeString(codecSelferC_UTF86836, string("path"))
+				z.EncSendContainerState(codecSelfer_containerMapValue6836)
 				yym8 := z.EncBinary()
 				_ = yym8
 				if false {
 				} else {
-					r.EncodeString(codecSelferC_UTF84586, string(x.Path))
+					r.EncodeString(codecSelferC_UTF86836, string(x.Path))
 				}
 			}
 			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem4586)
+				z.EncSendContainerState(codecSelfer_containerArrayElem6836)
 				if x.Data == nil {
 					r.EncodeNil()
 				} else {
@@ -130,9 +130,9 @@ func (x *SecretSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey4586)
-				r.EncodeString(codecSelferC_UTF84586, string("data"))
-				z.EncSendContainerState(codecSelfer_containerMapValue4586)
+				z.EncSendContainerState(codecSelfer_containerMapKey6836)
+				r.EncodeString(codecSelferC_UTF86836, string("data"))
+				z.EncSendContainerState(codecSelfer_containerMapValue6836)
 				if x.Data == nil {
 					r.EncodeNil()
 				} else {
@@ -145,7 +145,7 @@ func (x *SecretSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem4586)
+				z.EncSendContainerState(codecSelfer_containerArrayElem6836)
 				yym13 := z.EncBinary()
 				_ = yym13
 				if false {
@@ -153,9 +153,9 @@ func (x *SecretSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 					r.EncodeInt(int64(x.Renew))
 				}
 			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey4586)
-				r.EncodeString(codecSelferC_UTF84586, string("renew"))
-				z.EncSendContainerState(codecSelfer_containerMapValue4586)
+				z.EncSendContainerState(codecSelfer_containerMapKey6836)
+				r.EncodeString(codecSelferC_UTF86836, string("renew"))
+				z.EncSendContainerState(codecSelfer_containerMapValue6836)
 				yym14 := z.EncBinary()
 				_ = yym14
 				if false {
@@ -164,16 +164,43 @@ func (x *SecretSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd4586)
+				z.EncSendContainerState(codecSelfer_containerArrayElem6836)
+				if x.Annotations == nil {
+					r.EncodeNil()
+				} else {
+					yym16 := z.EncBinary()
+					_ = yym16
+					if false {
+					} else {
+						z.F.EncMapStringStringV(x.Annotations, false, e)
+					}
+				}
 			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd4586)
+				z.EncSendContainerState(codecSelfer_containerMapKey6836)
+				r.EncodeString(codecSelferC_UTF86836, string("annotations"))
+				z.EncSendContainerState(codecSelfer_containerMapValue6836)
+				if x.Annotations == nil {
+					r.EncodeNil()
+				} else {
+					yym17 := z.EncBinary()
+					_ = yym17
+					if false {
+					} else {
+						z.F.EncMapStringStringV(x.Annotations, false, e)
+					}
+				}
+			}
+			if yyr2 || yy2arr2 {
+				z.EncSendContainerState(codecSelfer_containerArrayEnd6836)
+			} else {
+				z.EncSendContainerState(codecSelfer_containerMapEnd6836)
 			}
 		}
 	}
 }
 
 func (x *SecretSpec) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer4586
+	var h codecSelfer6836
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 	yym1 := z.DecBinary()
@@ -182,28 +209,28 @@ func (x *SecretSpec) CodecDecodeSelf(d *codec1978.Decoder) {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		yyct2 := r.ContainerType()
-		if yyct2 == codecSelferValueTypeMap4586 {
+		if yyct2 == codecSelferValueTypeMap6836 {
 			yyl2 := r.ReadMapStart()
 			if yyl2 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd4586)
+				z.DecSendContainerState(codecSelfer_containerMapEnd6836)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2, d)
 			}
-		} else if yyct2 == codecSelferValueTypeArray4586 {
+		} else if yyct2 == codecSelferValueTypeArray6836 {
 			yyl2 := r.ReadArrayStart()
 			if yyl2 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd4586)
+				z.DecSendContainerState(codecSelfer_containerArrayEnd6836)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2, d)
 			}
 		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr4586)
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr6836)
 		}
 	}
 }
 
 func (x *SecretSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer4586
+	var h codecSelfer6836
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 	var yys3Slc = z.DecScratchBuffer() // default slice to decode into
@@ -219,10 +246,10 @@ func (x *SecretSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		z.DecSendContainerState(codecSelfer_containerMapKey4586)
+		z.DecSendContainerState(codecSelfer_containerMapKey6836)
 		yys3Slc = r.DecodeBytes(yys3Slc, true, true)
 		yys3 := string(yys3Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue4586)
+		z.DecSendContainerState(codecSelfer_containerMapValue6836)
 		switch yys3 {
 		case "type":
 			if r.TryDecodeAsNil() {
@@ -267,121 +294,155 @@ func (x *SecretSpec) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 					*((*int64)(yyv9)) = int64(r.DecodeInt(64))
 				}
 			}
+		case "annotations":
+			if r.TryDecodeAsNil() {
+				x.Annotations = nil
+			} else {
+				yyv11 := &x.Annotations
+				yym12 := z.DecBinary()
+				_ = yym12
+				if false {
+				} else {
+					z.F.DecMapStringStringX(yyv11, false, d)
+				}
+			}
 		default:
 			z.DecStructFieldNotFound(-1, yys3)
 		} // end switch yys3
 	} // end for yyj3
-	z.DecSendContainerState(codecSelfer_containerMapEnd4586)
+	z.DecSendContainerState(codecSelfer_containerMapEnd6836)
 }
 
 func (x *SecretSpec) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer4586
+	var h codecSelfer6836
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
-	var yyj11 int
-	var yyb11 bool
-	var yyhl11 bool = l >= 0
-	yyj11++
-	if yyhl11 {
-		yyb11 = yyj11 > l
+	var yyj13 int
+	var yyb13 bool
+	var yyhl13 bool = l >= 0
+	yyj13++
+	if yyhl13 {
+		yyb13 = yyj13 > l
 	} else {
-		yyb11 = r.CheckBreak()
+		yyb13 = r.CheckBreak()
 	}
-	if yyb11 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd4586)
+	if yyb13 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd6836)
 		return
 	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem4586)
+	z.DecSendContainerState(codecSelfer_containerArrayElem6836)
 	if r.TryDecodeAsNil() {
 		x.Type = ""
 	} else {
-		yyv12 := &x.Type
-		yyv12.CodecDecodeSelf(d)
+		yyv14 := &x.Type
+		yyv14.CodecDecodeSelf(d)
 	}
-	yyj11++
-	if yyhl11 {
-		yyb11 = yyj11 > l
+	yyj13++
+	if yyhl13 {
+		yyb13 = yyj13 > l
 	} else {
-		yyb11 = r.CheckBreak()
+		yyb13 = r.CheckBreak()
 	}
-	if yyb11 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd4586)
+	if yyb13 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd6836)
 		return
 	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem4586)
+	z.DecSendContainerState(codecSelfer_containerArrayElem6836)
 	if r.TryDecodeAsNil() {
 		x.Path = ""
 	} else {
-		yyv13 := &x.Path
-		yym14 := z.DecBinary()
-		_ = yym14
-		if false {
-		} else {
-			*((*string)(yyv13)) = r.DecodeString()
-		}
-	}
-	yyj11++
-	if yyhl11 {
-		yyb11 = yyj11 > l
-	} else {
-		yyb11 = r.CheckBreak()
-	}
-	if yyb11 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd4586)
-		return
-	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem4586)
-	if r.TryDecodeAsNil() {
-		x.Data = nil
-	} else {
-		yyv15 := &x.Data
+		yyv15 := &x.Path
 		yym16 := z.DecBinary()
 		_ = yym16
 		if false {
 		} else {
-			z.F.DecMapStringIntfX(yyv15, false, d)
+			*((*string)(yyv15)) = r.DecodeString()
 		}
 	}
-	yyj11++
-	if yyhl11 {
-		yyb11 = yyj11 > l
+	yyj13++
+	if yyhl13 {
+		yyb13 = yyj13 > l
 	} else {
-		yyb11 = r.CheckBreak()
+		yyb13 = r.CheckBreak()
 	}
-	if yyb11 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd4586)
+	if yyb13 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd6836)
 		return
 	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem4586)
+	z.DecSendContainerState(codecSelfer_containerArrayElem6836)
 	if r.TryDecodeAsNil() {
-		x.Renew = 0
+		x.Data = nil
 	} else {
-		yyv17 := &x.Renew
+		yyv17 := &x.Data
 		yym18 := z.DecBinary()
 		_ = yym18
 		if false {
 		} else {
-			*((*int64)(yyv17)) = int64(r.DecodeInt(64))
+			z.F.DecMapStringIntfX(yyv17, false, d)
+		}
+	}
+	yyj13++
+	if yyhl13 {
+		yyb13 = yyj13 > l
+	} else {
+		yyb13 = r.CheckBreak()
+	}
+	if yyb13 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd6836)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem6836)
+	if r.TryDecodeAsNil() {
+		x.Renew = 0
+	} else {
+		yyv19 := &x.Renew
+		yym20 := z.DecBinary()
+		_ = yym20
+		if false {
+		} else {
+			*((*int64)(yyv19)) = int64(r.DecodeInt(64))
+		}
+	}
+	yyj13++
+	if yyhl13 {
+		yyb13 = yyj13 > l
+	} else {
+		yyb13 = r.CheckBreak()
+	}
+	if yyb13 {
+		z.DecSendContainerState(codecSelfer_containerArrayEnd6836)
+		return
+	}
+	z.DecSendContainerState(codecSelfer_containerArrayElem6836)
+	if r.TryDecodeAsNil() {
+		x.Annotations = nil
+	} else {
+		yyv21 := &x.Annotations
+		yym22 := z.DecBinary()
+		_ = yym22
+		if false {
+		} else {
+			z.F.DecMapStringStringX(yyv21, false, d)
 		}
 	}
 	for {
-		yyj11++
-		if yyhl11 {
-			yyb11 = yyj11 > l
+		yyj13++
+		if yyhl13 {
+			yyb13 = yyj13 > l
 		} else {
-			yyb11 = r.CheckBreak()
+			yyb13 = r.CheckBreak()
 		}
-		if yyb11 {
+		if yyb13 {
 			break
 		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem4586)
-		z.DecStructFieldNotFound(yyj11-1, "")
+		z.DecSendContainerState(codecSelfer_containerArrayElem6836)
+		z.DecStructFieldNotFound(yyj13-1, "")
 	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd4586)
+	z.DecSendContainerState(codecSelfer_containerArrayEnd6836)
 }
 
 func (x *SecretClaim) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer4586
+	var h codecSelfer6836
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	if x == nil {
@@ -414,57 +475,57 @@ func (x *SecretClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 				yynn2 = 0
 			}
 			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem4586)
+				z.EncSendContainerState(codecSelfer_containerArrayElem6836)
 				if yyq2[0] {
 					yym4 := z.EncBinary()
 					_ = yym4
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF84586, string(x.Kind))
+						r.EncodeString(codecSelferC_UTF86836, string(x.Kind))
 					}
 				} else {
-					r.EncodeString(codecSelferC_UTF84586, "")
+					r.EncodeString(codecSelferC_UTF86836, "")
 				}
 			} else {
 				if yyq2[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey4586)
-					r.EncodeString(codecSelferC_UTF84586, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue4586)
+					z.EncSendContainerState(codecSelfer_containerMapKey6836)
+					r.EncodeString(codecSelferC_UTF86836, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue6836)
 					yym5 := z.EncBinary()
 					_ = yym5
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF84586, string(x.Kind))
+						r.EncodeString(codecSelferC_UTF86836, string(x.Kind))
 					}
 				}
 			}
 			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem4586)
+				z.EncSendContainerState(codecSelfer_containerArrayElem6836)
 				if yyq2[1] {
 					yym7 := z.EncBinary()
 					_ = yym7
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF84586, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF86836, string(x.APIVersion))
 					}
 				} else {
-					r.EncodeString(codecSelferC_UTF84586, "")
+					r.EncodeString(codecSelferC_UTF86836, "")
 				}
 			} else {
 				if yyq2[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey4586)
-					r.EncodeString(codecSelferC_UTF84586, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue4586)
+					z.EncSendContainerState(codecSelfer_containerMapKey6836)
+					r.EncodeString(codecSelferC_UTF86836, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue6836)
 					yym8 := z.EncBinary()
 					_ = yym8
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF84586, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF86836, string(x.APIVersion))
 					}
 				}
 			}
 			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem4586)
+				z.EncSendContainerState(codecSelfer_containerArrayElem6836)
 				if yyq2[2] {
 					yy10 := &x.ObjectMeta
 					yy10.CodecEncodeSelf(e)
@@ -473,35 +534,35 @@ func (x *SecretClaim) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey4586)
-					r.EncodeString(codecSelferC_UTF84586, string("metadata"))
-					z.EncSendContainerState(codecSelfer_containerMapValue4586)
+					z.EncSendContainerState(codecSelfer_containerMapKey6836)
+					r.EncodeString(codecSelferC_UTF86836, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue6836)
 					yy12 := &x.ObjectMeta
 					yy12.CodecEncodeSelf(e)
 				}
 			}
 			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem4586)
+				z.EncSendContainerState(codecSelfer_containerArrayElem6836)
 				yy15 := &x.Spec
 				yy15.CodecEncodeSelf(e)
 			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey4586)
-				r.EncodeString(codecSelferC_UTF84586, string("spec"))
-				z.EncSendContainerState(codecSelfer_containerMapValue4586)
+				z.EncSendContainerState(codecSelfer_containerMapKey6836)
+				r.EncodeString(codecSelferC_UTF86836, string("spec"))
+				z.EncSendContainerState(codecSelfer_containerMapValue6836)
 				yy17 := &x.Spec
 				yy17.CodecEncodeSelf(e)
 			}
 			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd4586)
+				z.EncSendContainerState(codecSelfer_containerArrayEnd6836)
 			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd4586)
+				z.EncSendContainerState(codecSelfer_containerMapEnd6836)
 			}
 		}
 	}
 }
 
 func (x *SecretClaim) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer4586
+	var h codecSelfer6836
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 	yym1 := z.DecBinary()
@@ -510,28 +571,28 @@ func (x *SecretClaim) CodecDecodeSelf(d *codec1978.Decoder) {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		yyct2 := r.ContainerType()
-		if yyct2 == codecSelferValueTypeMap4586 {
+		if yyct2 == codecSelferValueTypeMap6836 {
 			yyl2 := r.ReadMapStart()
 			if yyl2 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd4586)
+				z.DecSendContainerState(codecSelfer_containerMapEnd6836)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2, d)
 			}
-		} else if yyct2 == codecSelferValueTypeArray4586 {
+		} else if yyct2 == codecSelferValueTypeArray6836 {
 			yyl2 := r.ReadArrayStart()
 			if yyl2 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd4586)
+				z.DecSendContainerState(codecSelfer_containerArrayEnd6836)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2, d)
 			}
 		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr4586)
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr6836)
 		}
 	}
 }
 
 func (x *SecretClaim) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer4586
+	var h codecSelfer6836
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 	var yys3Slc = z.DecScratchBuffer() // default slice to decode into
@@ -547,10 +608,10 @@ func (x *SecretClaim) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		z.DecSendContainerState(codecSelfer_containerMapKey4586)
+		z.DecSendContainerState(codecSelfer_containerMapKey6836)
 		yys3Slc = r.DecodeBytes(yys3Slc, true, true)
 		yys3 := string(yys3Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue4586)
+		z.DecSendContainerState(codecSelfer_containerMapValue6836)
 		switch yys3 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -594,11 +655,11 @@ func (x *SecretClaim) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3)
 		} // end switch yys3
 	} // end for yyj3
-	z.DecSendContainerState(codecSelfer_containerMapEnd4586)
+	z.DecSendContainerState(codecSelfer_containerMapEnd6836)
 }
 
 func (x *SecretClaim) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer4586
+	var h codecSelfer6836
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 	var yyj10 int
@@ -611,10 +672,10 @@ func (x *SecretClaim) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb10 = r.CheckBreak()
 	}
 	if yyb10 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd4586)
+		z.DecSendContainerState(codecSelfer_containerArrayEnd6836)
 		return
 	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem4586)
+	z.DecSendContainerState(codecSelfer_containerArrayElem6836)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -633,10 +694,10 @@ func (x *SecretClaim) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb10 = r.CheckBreak()
 	}
 	if yyb10 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd4586)
+		z.DecSendContainerState(codecSelfer_containerArrayEnd6836)
 		return
 	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem4586)
+	z.DecSendContainerState(codecSelfer_containerArrayElem6836)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -655,10 +716,10 @@ func (x *SecretClaim) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb10 = r.CheckBreak()
 	}
 	if yyb10 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd4586)
+		z.DecSendContainerState(codecSelfer_containerArrayEnd6836)
 		return
 	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem4586)
+	z.DecSendContainerState(codecSelfer_containerArrayElem6836)
 	if r.TryDecodeAsNil() {
 		x.ObjectMeta = pkg3_api.ObjectMeta{}
 	} else {
@@ -672,10 +733,10 @@ func (x *SecretClaim) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		yyb10 = r.CheckBreak()
 	}
 	if yyb10 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd4586)
+		z.DecSendContainerState(codecSelfer_containerArrayEnd6836)
 		return
 	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem4586)
+	z.DecSendContainerState(codecSelfer_containerArrayElem6836)
 	if r.TryDecodeAsNil() {
 		x.Spec = SecretSpec{}
 	} else {
@@ -692,14 +753,14 @@ func (x *SecretClaim) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
 		if yyb10 {
 			break
 		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem4586)
+		z.DecSendContainerState(codecSelfer_containerArrayElem6836)
 		z.DecStructFieldNotFound(yyj10-1, "")
 	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd4586)
+	z.DecSendContainerState(codecSelfer_containerArrayEnd6836)
 }
 
 func (x *SecretClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
-	var h codecSelfer4586
+	var h codecSelfer6836
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	if x == nil {
@@ -732,57 +793,57 @@ func (x *SecretClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				yynn2 = 0
 			}
 			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem4586)
+				z.EncSendContainerState(codecSelfer_containerArrayElem6836)
 				if yyq2[0] {
 					yym4 := z.EncBinary()
 					_ = yym4
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF84586, string(x.Kind))
+						r.EncodeString(codecSelferC_UTF86836, string(x.Kind))
 					}
 				} else {
-					r.EncodeString(codecSelferC_UTF84586, "")
+					r.EncodeString(codecSelferC_UTF86836, "")
 				}
 			} else {
 				if yyq2[0] {
-					z.EncSendContainerState(codecSelfer_containerMapKey4586)
-					r.EncodeString(codecSelferC_UTF84586, string("kind"))
-					z.EncSendContainerState(codecSelfer_containerMapValue4586)
+					z.EncSendContainerState(codecSelfer_containerMapKey6836)
+					r.EncodeString(codecSelferC_UTF86836, string("kind"))
+					z.EncSendContainerState(codecSelfer_containerMapValue6836)
 					yym5 := z.EncBinary()
 					_ = yym5
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF84586, string(x.Kind))
+						r.EncodeString(codecSelferC_UTF86836, string(x.Kind))
 					}
 				}
 			}
 			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem4586)
+				z.EncSendContainerState(codecSelfer_containerArrayElem6836)
 				if yyq2[1] {
 					yym7 := z.EncBinary()
 					_ = yym7
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF84586, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF86836, string(x.APIVersion))
 					}
 				} else {
-					r.EncodeString(codecSelferC_UTF84586, "")
+					r.EncodeString(codecSelferC_UTF86836, "")
 				}
 			} else {
 				if yyq2[1] {
-					z.EncSendContainerState(codecSelfer_containerMapKey4586)
-					r.EncodeString(codecSelferC_UTF84586, string("apiVersion"))
-					z.EncSendContainerState(codecSelfer_containerMapValue4586)
+					z.EncSendContainerState(codecSelfer_containerMapKey6836)
+					r.EncodeString(codecSelferC_UTF86836, string("apiVersion"))
+					z.EncSendContainerState(codecSelfer_containerMapValue6836)
 					yym8 := z.EncBinary()
 					_ = yym8
 					if false {
 					} else {
-						r.EncodeString(codecSelferC_UTF84586, string(x.APIVersion))
+						r.EncodeString(codecSelferC_UTF86836, string(x.APIVersion))
 					}
 				}
 			}
 			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem4586)
+				z.EncSendContainerState(codecSelfer_containerArrayElem6836)
 				if yyq2[2] {
 					yy10 := &x.ListMeta
 					yym11 := z.EncBinary()
@@ -797,9 +858,9 @@ func (x *SecretClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			} else {
 				if yyq2[2] {
-					z.EncSendContainerState(codecSelfer_containerMapKey4586)
-					r.EncodeString(codecSelferC_UTF84586, string("metadata"))
-					z.EncSendContainerState(codecSelfer_containerMapValue4586)
+					z.EncSendContainerState(codecSelfer_containerMapKey6836)
+					r.EncodeString(codecSelferC_UTF86836, string("metadata"))
+					z.EncSendContainerState(codecSelfer_containerMapValue6836)
 					yy12 := &x.ListMeta
 					yym13 := z.EncBinary()
 					_ = yym13
@@ -811,7 +872,7 @@ func (x *SecretClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayElem4586)
+				z.EncSendContainerState(codecSelfer_containerArrayElem6836)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -823,9 +884,9 @@ func (x *SecretClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 					}
 				}
 			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey4586)
-				r.EncodeString(codecSelferC_UTF84586, string("items"))
-				z.EncSendContainerState(codecSelfer_containerMapValue4586)
+				z.EncSendContainerState(codecSelfer_containerMapKey6836)
+				r.EncodeString(codecSelferC_UTF86836, string("items"))
+				z.EncSendContainerState(codecSelfer_containerMapValue6836)
 				if x.Items == nil {
 					r.EncodeNil()
 				} else {
@@ -838,16 +899,16 @@ func (x *SecretClaimList) CodecEncodeSelf(e *codec1978.Encoder) {
 				}
 			}
 			if yyr2 || yy2arr2 {
-				z.EncSendContainerState(codecSelfer_containerArrayEnd4586)
+				z.EncSendContainerState(codecSelfer_containerArrayEnd6836)
 			} else {
-				z.EncSendContainerState(codecSelfer_containerMapEnd4586)
+				z.EncSendContainerState(codecSelfer_containerMapEnd6836)
 			}
 		}
 	}
 }
 
 func (x *SecretClaimList) CodecDecodeSelf(d *codec1978.Decoder) {
-	var h codecSelfer4586
+	var h codecSelfer6836
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 	yym1 := z.DecBinary()
@@ -856,28 +917,28 @@ func (x *SecretClaimList) CodecDecodeSelf(d *codec1978.Decoder) {
 	} else if z.HasExtensions() && z.DecExt(x) {
 	} else {
 		yyct2 := r.ContainerType()
-		if yyct2 == codecSelferValueTypeMap4586 {
+		if yyct2 == codecSelferValueTypeMap6836 {
 			yyl2 := r.ReadMapStart()
 			if yyl2 == 0 {
-				z.DecSendContainerState(codecSelfer_containerMapEnd4586)
+				z.DecSendContainerState(codecSelfer_containerMapEnd6836)
 			} else {
 				x.codecDecodeSelfFromMap(yyl2, d)
 			}
-		} else if yyct2 == codecSelferValueTypeArray4586 {
+		} else if yyct2 == codecSelferValueTypeArray6836 {
 			yyl2 := r.ReadArrayStart()
 			if yyl2 == 0 {
-				z.DecSendContainerState(codecSelfer_containerArrayEnd4586)
+				z.DecSendContainerState(codecSelfer_containerArrayEnd6836)
 			} else {
 				x.codecDecodeSelfFromArray(yyl2, d)
 			}
 		} else {
-			panic(codecSelferOnlyMapOrArrayEncodeToStructErr4586)
+			panic(codecSelferOnlyMapOrArrayEncodeToStructErr6836)
 		}
 	}
 }
 
 func (x *SecretClaimList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
-	var h codecSelfer4586
+	var h codecSelfer6836
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 	var yys3Slc = z.DecScratchBuffer() // default slice to decode into
@@ -893,10 +954,10 @@ func (x *SecretClaimList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 				break
 			}
 		}
-		z.DecSendContainerState(codecSelfer_containerMapKey4586)
+		z.DecSendContainerState(codecSelfer_containerMapKey6836)
 		yys3Slc = r.DecodeBytes(yys3Slc, true, true)
 		yys3 := string(yys3Slc)
-		z.DecSendContainerState(codecSelfer_containerMapValue4586)
+		z.DecSendContainerState(codecSelfer_containerMapValue6836)
 		switch yys3 {
 		case "kind":
 			if r.TryDecodeAsNil() {
@@ -951,11 +1012,11 @@ func (x *SecretClaimList) codecDecodeSelfFromMap(l int, d *codec1978.Decoder) {
 			z.DecStructFieldNotFound(-1, yys3)
 		} // end switch yys3
 	} // end for yyj3
-	z.DecSendContainerState(codecSelfer_containerMapEnd4586)
+	z.DecSendContainerState(codecSelfer_containerMapEnd6836)
 }
 
 func (x *SecretClaimList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) {
-	var h codecSelfer4586
+	var h codecSelfer6836
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 	var yyj12 int
@@ -968,10 +1029,10 @@ func (x *SecretClaimList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb12 = r.CheckBreak()
 	}
 	if yyb12 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd4586)
+		z.DecSendContainerState(codecSelfer_containerArrayEnd6836)
 		return
 	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem4586)
+	z.DecSendContainerState(codecSelfer_containerArrayElem6836)
 	if r.TryDecodeAsNil() {
 		x.Kind = ""
 	} else {
@@ -990,10 +1051,10 @@ func (x *SecretClaimList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb12 = r.CheckBreak()
 	}
 	if yyb12 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd4586)
+		z.DecSendContainerState(codecSelfer_containerArrayEnd6836)
 		return
 	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem4586)
+	z.DecSendContainerState(codecSelfer_containerArrayElem6836)
 	if r.TryDecodeAsNil() {
 		x.APIVersion = ""
 	} else {
@@ -1012,10 +1073,10 @@ func (x *SecretClaimList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb12 = r.CheckBreak()
 	}
 	if yyb12 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd4586)
+		z.DecSendContainerState(codecSelfer_containerArrayEnd6836)
 		return
 	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem4586)
+	z.DecSendContainerState(codecSelfer_containerArrayElem6836)
 	if r.TryDecodeAsNil() {
 		x.ListMeta = pkg2_unversioned.ListMeta{}
 	} else {
@@ -1035,10 +1096,10 @@ func (x *SecretClaimList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		yyb12 = r.CheckBreak()
 	}
 	if yyb12 {
-		z.DecSendContainerState(codecSelfer_containerArrayEnd4586)
+		z.DecSendContainerState(codecSelfer_containerArrayEnd6836)
 		return
 	}
-	z.DecSendContainerState(codecSelfer_containerArrayElem4586)
+	z.DecSendContainerState(codecSelfer_containerArrayElem6836)
 	if r.TryDecodeAsNil() {
 		x.Items = nil
 	} else {
@@ -1060,27 +1121,27 @@ func (x *SecretClaimList) codecDecodeSelfFromArray(l int, d *codec1978.Decoder) 
 		if yyb12 {
 			break
 		}
-		z.DecSendContainerState(codecSelfer_containerArrayElem4586)
+		z.DecSendContainerState(codecSelfer_containerArrayElem6836)
 		z.DecStructFieldNotFound(yyj12-1, "")
 	}
-	z.DecSendContainerState(codecSelfer_containerArrayEnd4586)
+	z.DecSendContainerState(codecSelfer_containerArrayEnd6836)
 }
 
-func (x codecSelfer4586) encSliceSecretClaim(v []SecretClaim, e *codec1978.Encoder) {
-	var h codecSelfer4586
+func (x codecSelfer6836) encSliceSecretClaim(v []SecretClaim, e *codec1978.Encoder) {
+	var h codecSelfer6836
 	z, r := codec1978.GenHelperEncoder(e)
 	_, _, _ = h, z, r
 	r.EncodeArrayStart(len(v))
 	for _, yyv1 := range v {
-		z.EncSendContainerState(codecSelfer_containerArrayElem4586)
+		z.EncSendContainerState(codecSelfer_containerArrayElem6836)
 		yy2 := &yyv1
 		yy2.CodecEncodeSelf(e)
 	}
-	z.EncSendContainerState(codecSelfer_containerArrayEnd4586)
+	z.EncSendContainerState(codecSelfer_containerArrayEnd6836)
 }
 
-func (x codecSelfer4586) decSliceSecretClaim(v *[]SecretClaim, d *codec1978.Decoder) {
-	var h codecSelfer4586
+func (x codecSelfer6836) decSliceSecretClaim(v *[]SecretClaim, d *codec1978.Decoder) {
+	var h codecSelfer6836
 	z, r := codec1978.GenHelperDecoder(d)
 	_, _, _ = h, z, r
 
@@ -1105,7 +1166,7 @@ func (x codecSelfer4586) decSliceSecretClaim(v *[]SecretClaim, d *codec1978.Deco
 
 			yyrg1 := len(yyv1) > 0
 			yyv21 := yyv1
-			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 304)
+			yyrl1, yyrt1 = z.DecInferLen(yyl1, z.DecBasicHandle().MaxInitLen, 312)
 			if yyrt1 {
 				if yyrl1 <= cap(yyv1) {
 					yyv1 = yyv1[:yyrl1]

--- a/pkg/vault/controller_test.go
+++ b/pkg/vault/controller_test.go
@@ -3,38 +3,81 @@ package vault
 import (
 	"reflect"
 	"testing"
+	"time"
+
+	vaultapi "github.com/hashicorp/vault/api"
+	"github.com/roboll/kube-vault-controller/pkg/kube"
 )
 
-func Test_mergeAnnotations(t *testing.T) {
+func init() {
+
+	timeNow = func() time.Time {
+		t, _ := time.Parse("2006-01-02 15:04:05", "2017-01-20 01:02:03")
+		return t
+	}
+}
+
+func Test_buildSecretAnnotations(t *testing.T) {
 	tests := []struct {
-		name            string
-		userAnnotations map[string]string
-		baseAnnotations map[string]string
-		want            map[string]string
+		name   string
+		secret *vaultapi.Secret
+		claim  *kube.SecretClaim
+		want   map[string]string
 	}{
 		{
-			name:            "merge annotations maps",
-			userAnnotations: map[string]string{"hello": "world"},
-			baseAnnotations: map[string]string{"foo": "bar"},
-			want:            map[string]string{"hello": "world", "foo": "bar"},
+			name:   "merge annotations from secretspec",
+			secret: &vaultapi.Secret{},
+			claim: &kube.SecretClaim{
+				Spec: kube.SecretSpec{
+					Annotations: map[string]string{
+						"hello": "world",
+						"foo":   "bar",
+					},
+				},
+			},
+			want: map[string]string{
+				"hello": "world",
+				"foo":   "bar",
+				"vaultproject.io/lease-expiration": "1484874123",
+				"vaultproject.io/lease-id":         "",
+				"vaultproject.io/renewable":        "false",
+			},
 		},
 		{
-			name:            "user annotations will not overwrite base annotations",
-			userAnnotations: map[string]string{"hello": "universe"},
-			baseAnnotations: map[string]string{"hello": "world"},
-			want:            map[string]string{"hello": "world"},
+			name:   "user annotations will not overwrite base annotations",
+			secret: &vaultapi.Secret{},
+			claim: &kube.SecretClaim{
+				Spec: kube.SecretSpec{
+					Annotations: map[string]string{
+						"vaultproject.io/lease-expiration": "changed",
+						"vaultproject.io/lease-id":         "changed",
+						"vaultproject.io/renewable":        "changed",
+					},
+				},
+			},
+			want: map[string]string{
+				"vaultproject.io/lease-expiration": "1484874123",
+				"vaultproject.io/lease-id":         "",
+				"vaultproject.io/renewable":        "false",
+			},
 		},
 		{
-			name:            "user annotations is empty",
-			userAnnotations: map[string]string{},
-			baseAnnotations: map[string]string{"hello": "world"},
-			want:            map[string]string{"hello": "world"},
+			name:   "no user annotations supplied",
+			secret: &vaultapi.Secret{},
+			claim: &kube.SecretClaim{
+				Spec: kube.SecretSpec{},
+			},
+			want: map[string]string{
+				"vaultproject.io/lease-expiration": "1484874123",
+				"vaultproject.io/lease-id":         "",
+				"vaultproject.io/renewable":        "false",
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := mergeAnnotations(tt.userAnnotations, tt.baseAnnotations); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("mergeAnnotations() = %v, want %v", got, tt.want)
+			if got := buildSecretAnnotations(tt.secret, tt.claim); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("buildSecretAnnotations() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/vault/controller_test.go
+++ b/pkg/vault/controller_test.go
@@ -1,0 +1,41 @@
+package vault
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_mergeAnnotations(t *testing.T) {
+	tests := []struct {
+		name            string
+		userAnnotations map[string]string
+		baseAnnotations map[string]string
+		want            map[string]string
+	}{
+		{
+			name:            "merge annotations maps",
+			userAnnotations: map[string]string{"hello": "world"},
+			baseAnnotations: map[string]string{"foo": "bar"},
+			want:            map[string]string{"hello": "world", "foo": "bar"},
+		},
+		{
+			name:            "user annotations will not overwrite base annotations",
+			userAnnotations: map[string]string{"hello": "universe"},
+			baseAnnotations: map[string]string{"hello": "world"},
+			want:            map[string]string{"hello": "world"},
+		},
+		{
+			name:            "user annotations is empty",
+			userAnnotations: map[string]string{},
+			baseAnnotations: map[string]string{"hello": "world"},
+			want:            map[string]string{"hello": "world"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mergeAnnotations(tt.userAnnotations, tt.baseAnnotations); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("mergeAnnotations() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Originally I thought it would be nice to just grab whatever annotations
the secretClaim had and stick them onto the secret. The main problem
with this is that there are all kind of auto generated metadata being
added by Kubernetes and could cause some weirdness.

Closes: #11