### PR TITLE
Build kube-vault-controller with Golang 1.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+kube-vault-controller

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,23 @@ TAG     := $(shell git describe --tags --abbrev=0 HEAD)
 PKGS    := $(shell go list ./... | grep -v /vendor/)
 PREFIX  := quay.io/roboll
 
+GO_VERSION := 1.7
+GO_BUILD_PATH := /go/src/github.com/roboll/kube-vault-controller
+
 generate:
 	go generate ${PKGS}
 .PHONY: generate
 
 build:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a .
+	docker run \
+		--rm \
+		--volume ${PWD}:${GO_BUILD_PATH} \
+		--workdir ${GO_BUILD_PATH} \
+		--env GOOS=linux \
+		--env GOARCH=amd64 \
+		--env CGO_ENABLED=0 \
+		golang:${GO_VERSION} \
+		go build -a .
 .PHONY: build
 
 check:


### PR DESCRIPTION
Building kube-vault-controller with the latest Golang version results in
a subtle bug. The bug is triggered when the Kubernetes API service is
restarted and sends a GOAWAY to kube-vault-controller. When this happens
kube-vault-controller will never properly recover and will continuously
spam these logs:

```
E0526 14:27:42.307367  380252 streamwatcher.go:109] Unable to decode an event from the watch stream: http2: server sent GOAWAY and closed the connection; LastStreamID=11, ErrCode=NO_ERROR, debug=""
E0526 14:27:42.307467  380252 streamwatcher.go:109] Unable to decode an event from the watch stream: http2: server sent GOAWAY and closed the connection; LastStreamID=11, ErrCode=NO_ERROR, debug=""
E0526 14:27:43.310858  380252 reflector.go:199] github.com/roboll/kube-vault-controller/vendor/k8s.io/client-go/tools/cache/reflector.go:94: Failed to list *kube.SecretClaim: Get https://127.0.0.1:46205/apis/vaultproject.io/v1/secretclaims: read tcp 127.0.0.1:35174->127.0.0.1:46205: read: connection reset by peer
E0526 14:27:43.310920  380252 reflector.go:199] github.com/roboll/kube-vault-controller/vendor/k8s.io/client-go/tools/cache/reflector.go:94: Failed to list *v1.Secret: Get https://127.0.0.1:46205/api/v1/secrets?resourceVersion=0: read tcp 127.0.0.1:35172->127.0.0.1:46205: read: connection reset by peer
```

The version is being pinned to make sure that the correct Golang version
is used when building until dependencies can be safely updated.